### PR TITLE
implement endpoints update, soft delete, and restore

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -4,7 +4,7 @@ const userService = new UserService(db);
 const { hashPassword, verifyPassword } = require("../utilities/hashing");
 const RoleService = require("../services/RoleService");
 const roleService = new RoleService(db);
-const { generateToken, verifyToken } = require("../utilities/jwt");
+const { generateToken } = require("../utilities/jwt");
 
 async function register(req, res) {
   const { firstName, lastName, username, email, password } = req.body;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -43,15 +43,6 @@ async function login(req, res) {
     throw new Error("No user with this Email exist");
   }
 
-  //cheking if the user is soft deleted
-  if (user.deletedAt) {
-    return res.status(403).json({
-      status: "forbidden",
-      statusCode: 403,
-      data: { result: "This account has been deleted or deactivated." },
-    });
-  }
-
   // verifying the user - use hashedPassword instead of encryptedPassword
   const verifyUser = await verifyPassword(password, user.salt, user.hashedPassword);
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -4,7 +4,7 @@ const userService = new UserService(db);
 const { hashPassword, verifyPassword } = require("../utilities/hashing");
 const RoleService = require("../services/RoleService");
 const roleService = new RoleService(db);
-const { generateToken } = require("../utilities/jwt");
+const { generateToken, verifyToken } = require("../utilities/jwt");
 
 async function register(req, res) {
   const { firstName, lastName, username, email, password } = req.body;
@@ -36,10 +36,20 @@ async function login(req, res) {
   const { email, password } = req.body;
 
   // finding the user - note we pass false to include the password fields
-  const user = await userService.getOneEmail(email, false);
+  const user = await userService.getOneEmail(email, false, false);
 
+  //Cheking if the user exist
   if (!user) {
     throw new Error("No user with this Email exist");
+  }
+
+  //cheking if the user is soft deleted
+  if (user.deletedAt) {
+    return res.status(403).json({
+      status: "forbidden",
+      statusCode: 403,
+      data: { result: "This account has been deleted or deactivated." },
+    });
   }
 
   // verifying the user - use hashedPassword instead of encryptedPassword

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -2,6 +2,7 @@ const { UserService, ProjectServices } = require("../services/index");
 const { db } = require("../models");
 const userService = new UserService(db);
 const projectServices = new ProjectServices(db);
+const sanitizeUser = require("../utilities/sanitizeUser");
 
 //This for getting the user based of Id.
 async function getUser(req, res, next) {
@@ -9,15 +10,18 @@ async function getUser(req, res, next) {
   const user = await userService.getOneId(id);
 
   if (!user) {
-    throw new Error("Failed to retrive user");
+    throw new Error("User not found");
   }
 
-  res.status(200).json(user);
+  res.status(200).json({
+    status: "success",
+    statusCode: 200,
+    data: sanitizeUser(user),
+  });
 }
 
 async function getMe(req, res, next) {
   const id = req.user.id;
-  console.log("req.user:", req.user);
   const user = await userService.getOneId(id);
 
   if (!user) {
@@ -32,24 +36,20 @@ async function getMe(req, res, next) {
 }
 
 async function updateMe(req, res, next) {
-  try {
-    const id = req.user.id;
+  const id = req.user.id;
 
-    const user = await userService.getOneId(id);
-    if (!user) {
-      return res.status(404).json({ message: "User not found" });
-    }
-
-    const updatedUser = await userService.update(id, req.body);
-
-    res.status(200).json({
-      status: "success",
-      statusCode: 200,
-      data: updatedUser,
-    });
-  } catch (error) {
-    next(error);
+  const user = await userService.getOneId(id);
+  if (!user) {
+    throw new Error("User not found");
   }
+
+  const updatedUser = await userService.update(id, req.body);
+
+  res.status(200).json({
+    status: "success",
+    statusCode: 200,
+    data: sanitizeUser(user),
+  });
 }
 
 async function softDeletedUser(req, res, next) {
@@ -59,11 +59,7 @@ async function softDeletedUser(req, res, next) {
     const deletedUser = await userService.softDelete(id);
 
     if (!deletedUser) {
-      return res.status(404).json({
-        status: "fail",
-        statusCode: 404,
-        message: "User not found or already deleted.",
-      });
+      throw new Error("User not found");
     }
 
     res.status(200).json({
@@ -78,17 +74,13 @@ async function softDeletedUser(req, res, next) {
 
 //this should be added to the AdminController
 async function getAllSoftDeleted(req, res, next) {
-  try {
-    const deletedUsers = await userService.getAllDeleted();
+  const deletedUsers = await userService.getAllDeleted();
 
-    res.status(200).json({
-      status: "success",
-      statusCode: 200,
-      data: deletedUsers,
-    });
-  } catch (error) {
-    next(error);
-  }
+  res.status(200).json({
+    status: "success",
+    statusCode: 200,
+    data: deletedUsers,
+  });
 }
 
 module.exports = { getUser, updateMe, getMe, softDeletedUser, getAllSoftDeleted };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,4 +1,94 @@
-const { UserServices, ProjectServices } = require("../services/index");
+const { UserService, ProjectServices } = require("../services/index");
 const { db } = require("../models");
-const userServices = new UserServices(db);
+const userService = new UserService(db);
 const projectServices = new ProjectServices(db);
+
+//This for getting the user based of Id.
+async function getUser(req, res, next) {
+  const id = req.params.id;
+  const user = await userService.getOneId(id);
+
+  if (!user) {
+    throw new Error("Failed to retrive user");
+  }
+
+  res.status(200).json(user);
+}
+
+async function getMe(req, res, next) {
+  const id = req.user.id;
+  console.log("req.user:", req.user);
+  const user = await userService.getOneId(id);
+
+  if (!user) {
+    throw new Error("Failed to retrive user");
+  }
+
+  res.status(200).json({
+    status: "success",
+    statusCode: 200,
+    data: user,
+  });
+}
+
+async function updateMe(req, res, next) {
+  try {
+    const id = req.user.id;
+
+    const user = await userService.getOneId(id);
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const updatedUser = await userService.update(id, req.body);
+
+    res.status(200).json({
+      status: "success",
+      statusCode: 200,
+      data: updatedUser,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function softDeletedUser(req, res, next) {
+  try {
+    const id = req.user.id;
+
+    const deletedUser = await userService.softDelete(id);
+
+    if (!deletedUser) {
+      return res.status(404).json({
+        status: "fail",
+        statusCode: 404,
+        message: "User not found or already deleted.",
+      });
+    }
+
+    res.status(200).json({
+      status: "success",
+      statusCode: 200,
+      data: deletedUser,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+//this should be added to the AdminController
+async function getAllSoftDeleted(req, res, next) {
+  try {
+    const deletedUsers = await userService.getAllDeleted();
+
+    res.status(200).json({
+      status: "success",
+      statusCode: 200,
+      data: deletedUsers,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+module.exports = { getUser, updateMe, getMe, softDeletedUser, getAllSoftDeleted };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -16,7 +16,7 @@ async function getUser(req, res, next) {
   res.status(200).json({
     status: "success",
     statusCode: 200,
-    data: sanitizeUser(user),
+    data: user,
   });
 }
 

--- a/models/User.js
+++ b/models/User.js
@@ -80,6 +80,7 @@ module.exports = (sequelize, Sequelize) => {
       },
     },
     {
+      paranoid: true,
       timestamps: true,
       tableName: "Users",
       indexese: [{ fields: ["roleId"] }, { fields: ["email"] }],

--- a/routes/users.js
+++ b/routes/users.js
@@ -18,7 +18,7 @@ router.get("/deleted", asyncHandler(authenticate), asyncHandler(getAllSoftDelete
 router.get("/:id", asyncHandler(getUser));
 
 //Update user info.
-router.put("/:id", asyncHandler(authenticate), asyncHandler(updateMe));
+router.put("/me", asyncHandler(authenticate), asyncHandler(updateMe));
 
 router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,8 +1,25 @@
 var express = require("express");
 var router = express.Router();
+const { getUser, updateMe, getMe, softDeletedUser, getAllSoftDeleted } = require("../controllers/userController");
+const { authenticate, hasRole, isAdmin, isSelfOrAdmin } = require("../middleware/authentication");
+const asyncHandler = require("../middleware/asyncHandler");
 
 router.get("/", function (req, res, next) {
   res.status(200).json({ message: "Welcome to the API" });
 });
+
+//GET USER/ME
+router.get("/me", asyncHandler(authenticate), asyncHandler(getMe));
+
+//this should be added to the AdminController
+router.get("/deleted", asyncHandler(authenticate), asyncHandler(getAllSoftDeleted));
+
+//GET USER/ID
+router.get("/:id", asyncHandler(getUser));
+
+//Update user info.
+router.put("/:id", asyncHandler(authenticate), asyncHandler(updateMe));
+
+router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
 
 module.exports = router;

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -1,4 +1,5 @@
 const { Op } = require("sequelize");
+const sanitizeUser = require("../utilities/sanitizeUser");
 
 class UserService {
   constructor(db) {
@@ -33,12 +34,16 @@ class UserService {
     });
   }
 
-  async getOneId(id) {
-    return this.User.findOne({
-      where: { id },
+  async getOneId(userId, options = {}) {
+    const user = await this.User.findOne({
+      where: { id: userId },
       include: [{ model: this.Role }],
       attributes: { exclude: ["hashedPassword", "salt", "roleId"] },
     });
+
+    if (!user) return null;
+
+    return sanitizeUser(user, options);
   }
 
   async create({ firstName, lastName, username, email, hashedPassword, salt, roleId }) {

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -1,3 +1,5 @@
+const { Op } = require("sequelize");
+
 class UserService {
   constructor(db) {
     this.client = db.sequelize;
@@ -12,14 +14,14 @@ class UserService {
     });
   }
 
-  async getOneEmail(email, exclude = true) {
+  async getOneEmail(email, exclude = true, paranoid = true) {
     return this.User.findOne({
       where: { email },
       include: [{ model: this.Role }],
       attributes: {
-        // eslint-disable-next-line max-len
-        exclude: exclude ? ["hashedPassword", "salt", "roleId"] : [], // Changed from encryptedPassword to hashedPassword
+        exclude: exclude ? ["hashedPassword", "salt", "roleId"] : [],
       },
+      paranoid, // if paranoid is false, deletedAt will be null
     });
   }
 
@@ -35,7 +37,7 @@ class UserService {
     return this.User.findOne({
       where: { id },
       include: [{ model: this.Role }],
-      attributes: { exclude: ["encryptedPassword", "salt", "roleId"] },
+      attributes: { exclude: ["hashedPassword", "salt", "roleId"] },
     });
   }
 
@@ -64,8 +66,23 @@ class UserService {
     return updatedUser;
   }
 
-  async delete(id) {
+  async softDelete(id) {
     return this.User.destroy({ where: { id } });
+  }
+
+  async getAllDeleted() {
+    return this.User.findAll({
+      where: {
+        deletedAt: {
+          [Op.ne]: null,
+        },
+      },
+      paranoid: false,
+    });
+  }
+
+  async restore(id) {
+    return this.User.restore({ where: { id } });
   }
 }
 

--- a/utilities/sanitizeUser.js
+++ b/utilities/sanitizeUser.js
@@ -1,0 +1,28 @@
+function sanitizeUser(user, options = {}) {
+  const { isOwner = false, isAdmin = false, includeId = false } = options;
+
+  const base = {
+    username: user.username,
+    displayName: user.displayName,
+    bio: user.bio,
+    avatarUrl: user.avatarUrl,
+    role: user.Role?.name || "user",
+  };
+
+  if (includeId) {
+    base.id = user.id;
+  }
+
+  if (isOwner || isAdmin) {
+    return {
+      ...base,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+    };
+  }
+
+  return base;
+}
+
+module.exports = sanitizeUser;


### PR DESCRIPTION
Implemented user-related endpoints with authentication and soft delete support.

- GET /users/me – Fetch authenticated user's profile
- PUT /users/me – Update user profile (displayName, bio, avatarUrl)
- DELETE /users/me – Soft delete (paranoid) authenticated user's account
- GET /users/:id – Public profile lookup by 
- GET /users/deleted – Admin-only route to fetch soft-deleted users
- Added route protection: authenticate
- Updated User model to support Sequelize's paranoid delete