### PR TITLE
afterDestroy hook for comments on user soft deletion 

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,4 +1,4 @@
-const { UserService} = require("../services/index");
+const { UserService } = require("../services/index");
 const { db } = require("../models");
 const userService = new UserService(db);
 const sanitizeUser = require("../utilities/sanitizeUser");
@@ -64,7 +64,7 @@ async function softDeletedUser(req, res, next) {
     res.status(200).json({
       status: "success",
       statusCode: 200,
-      data: deletedUser,
+      message: "User successfully deleted",
     });
   } catch (error) {
     next(error);

--- a/models/User.js
+++ b/models/User.js
@@ -101,5 +101,19 @@ module.exports = (sequelize, Sequelize) => {
       onDelete: "CASCADE",
     });
   };
+
+  User.addHook("afterDestroy", async (user, options) => {
+    await sequelize.models.Comment.update(
+      {
+        isDeleted: true,
+        userId: null,
+      },
+      {
+        where: { userId: user.id },
+        transaction: options.transaction,
+      }
+    );
+  });
+
   return User;
 };

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -86,7 +86,7 @@ class UserService {
       await user.destroy({ transaction });
       await transaction.commit();
 
-      return user;
+      return true;
     } catch (error) {
       if (transaction) await transaction.rollback();
       throw error;

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -72,7 +72,25 @@ class UserService {
   }
 
   async softDelete(id) {
-    return this.User.destroy({ where: { id } });
+    const user = await this.User.findByPk(id, {
+      include: [{ model: this.Role }],
+    });
+
+    if (!user) {
+      return null;
+    }
+
+    let transaction;
+    try {
+      transaction = await this.client.transaction();
+      await user.destroy({ transaction });
+      await transaction.commit();
+
+      return user;
+    } catch (error) {
+      if (transaction) await transaction.rollback();
+      throw error;
+    }
   }
 
   async getAllDeleted() {


### PR DESCRIPTION
- Changed UserService.softDelete to find the user instance first and then call destroy() on it
- Added transaction support
- Service now returns a boolean value instead of the user object
- Updated controller to return a success message instead of user data