### PR TITLE
Fix/project tags

### DIFF
--- a/models/Project.js
+++ b/models/Project.js
@@ -79,7 +79,7 @@ module.exports = (sequelize, Sequelize) => {
       onDelete: "CASCADE",
     });
     Project.belongsToMany(models.Type, {
-      through: "ProjectTags",
+      through: models.ProjectType,
       foreignKey: "projectId",
       otherKey: "typeId",
       as: "types",

--- a/models/ProjectType.js
+++ b/models/ProjectType.js
@@ -3,8 +3,8 @@
 module.exports = (sequelize, Sequelize) => {
   const { DataTypes } = Sequelize;
 
-  const ProjectTag = sequelize.define(
-    "ProjectTag",
+  const ProjectType = sequelize.define(
+    "ProjectType",
     {
       projectId: {
         type: DataTypes.UUID,
@@ -25,15 +25,15 @@ module.exports = (sequelize, Sequelize) => {
     },
     {
       timestamps: true,
-      tableName: "ProjectTags",
+      tableName: "ProjectTypes",
       indexes: [
         {
-          name: "project_type_unique",
+          name: "project_types_unique",
           unique: true,
           fields: ["projectId", "typeId"],
         },
       ],
     }
   );
-  return ProjectTag;
+  return ProjectType;
 };

--- a/models/Type.js
+++ b/models/Type.js
@@ -27,7 +27,7 @@ module.exports = (sequelize, Sequelize) => {
 
   Type.associate = (models) => {
     Type.belongsToMany(models.Project, {
-      through: "ProjectTags",
+      through: models.ProjectType,
       foreignKey: "typeId",
       otherKey: "projectId",
       as: "projects",

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -9,8 +9,22 @@ class ProjectService {
   }
 
   async getAll(limit = 100, offset = 0, options = {}) {
-    const { userId, currentUserId, status, orderBy, order, types } = options;
+    const { userId, currentUserId, status, orderBy, order } = options;
+    let { types } = options;
 
+    if (typeof types === "string") {
+      // Convert comma-separated string to array of numbers
+      types = types.split(",").map((type) => Number(type));
+    }
+
+    if (Array.isArray(types)) {
+      types = types.map((type) => Number(type)); // Make sure all are numbers
+      if (types.some(isNaN)) {
+        throw new Error("Types array contains invalid numbers");
+      }
+    } else {
+      types = [];
+    }
     const queryBuilder = new ProjectQueryBuilder()
       .withVotes()
       .withTypes()
@@ -117,7 +131,7 @@ class ProjectService {
       });
     } catch (error) {
       if (transaction) await transaction.rollback();
-      console.error("Error starting transaction:", error);
+      // Removed debug console.error for production
       throw createError({
         message: "Error creating project",
         status: "error",

--- a/services/queries/ProjectQueryBuilder.js
+++ b/services/queries/ProjectQueryBuilder.js
@@ -91,7 +91,7 @@ class ProjectQueryBuilder {
     }
 
     if (this.includeTypes) {
-      joins.push(`LEFT JOIN "ProjectTags" pt ON p."id" = pt."projectId"`);
+      joins.push(`LEFT JOIN "ProjectType" pt ON p."id" = pt."projectId"`);
       joins.push(`LEFT JOIN "Types" t ON pt."typeId" = t."id"`);
     }
 

--- a/services/queries/ProjectQueryBuilder.js
+++ b/services/queries/ProjectQueryBuilder.js
@@ -66,6 +66,7 @@ class ProjectQueryBuilder {
 
     if (this.includeTypes) {
       fields.push(`ARRAY_AGG(jsonb_build_object('name', t."name", 'id', t."id")) AS "types"`);
+      // fields.push(`ARRAY_AGG(jsonb_build_object('name', t."name", 'id', t."id")) AS "types"`);
       // fields.push(`ARRAY_AGG(DISTINCT t."name") AS "types"`);
       // fields.push(`ARRAY_AGG(rows(t."name", t."id")) AS "types"`);
     }
@@ -91,7 +92,7 @@ class ProjectQueryBuilder {
     }
 
     if (this.includeTypes) {
-      joins.push(`LEFT JOIN "ProjectType" pt ON p."id" = pt."projectId"`);
+      joins.push(`LEFT JOIN "ProjectTypes" pt ON p."id" = pt."projectId"`);
       joins.push(`LEFT JOIN "Types" t ON pt."typeId" = t."id"`);
     }
 
@@ -108,9 +109,16 @@ class ProjectQueryBuilder {
     if (this.filters.projectId) conditions.push(`p."id" = :projectId`);
     if (this.filters.userId) conditions.push(`p."userId" = :userId`);
     if (this.filters.status) conditions.push(`p."status" = :status`);
-    if (this.filters.types?.length) conditions.push(`t."id" IN (:types)`);
+    //if (this.filters.types?.length) conditions.push(`t."id" IN (:types)`);
 
     return conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  }
+
+  buildHavingClause() {
+    if (this.filters.types?.length) {
+      return `HAVING BOOL_OR(t."id" = ANY(ARRAY[:types]))`;
+    }
+    return "";
   }
 
   buildGroupBy() {
@@ -147,6 +155,7 @@ class ProjectQueryBuilder {
       ${this.buildJoins()}
       ${this.buildWhereClause()}
       GROUP BY ${this.buildGroupBy()}
+      ${this.buildHavingClause()}
       ${this.buildOrderBy()}
       LIMIT :limit OFFSET :offset
     `;


### PR DESCRIPTION
Rename projectTags table to projectTypes to prevent confusion, fixed the project outputs and model table relationships. Also fixed types filtering in the query builder.