### PR TITLE
Feature/rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,11 @@ if (process.env.CORS === "true") {
   app.use(cors());
 }
 
+// Security headers using Helmet
 app.use(helmet());
+
+// Disable the 'X-Powered-By' header for security
+app.disable("x-powered-by");
 
 app.use(
   createRateLimiter({
@@ -58,7 +62,8 @@ app.use(
 );
 
 app.use(logger("dev"));
-app.use(express.json());
+// limit the size of JSON payloads to prevent abuse, we are not currently using file uploads this should be sufficient
+app.use(express.json({ limit: "100kb" }));
 app.use(express.urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, "public")));
 

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const logger = require("morgan");
 const dotenv = require("dotenv");
 dotenv.config();
 var { errorResponse } = require("./utilities/response");
-var { createRateLimiter, createSlowDown } = require("./utilities/responseLimiting");
+var { createRateLimiter, createSlowDown } = require("./middleware");
 var helmet = require("helmet");
 
 //swagger

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const logger = require("morgan");
 const dotenv = require("dotenv");
 dotenv.config();
 var { errorResponse } = require("./utilities/response");
+var { createRateLimiter, createSlowDown } = require("./utilities/responseLimiting");
 
 //swagger
 const swaggerUi = require("swagger-ui-express");
@@ -36,6 +37,22 @@ var app = express();
 if (process.env.CORS === "true") {
   app.use(cors());
 }
+
+app.use(
+  createRateLimiter({
+    max: parseInt(process.env.RATE_LIMIT_MAX) || 600,
+    windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 10 * 60 * 1000, // 10 minutes
+    message: "Too many requests, please try again later.",
+  })
+);
+
+app.use(
+  createSlowDown({
+    delayAfter: parseInt(process.env.SLOW_DOWN_DELAY_AFTER) || 240,
+    delayMs: parseInt(process.env.SLOW_DOWN_DELAY_MS) || 500,
+    windowMs: parseInt(process.env.SLOW_DOWN_WINDOW_MS) || 5 * 60 * 1000, // 5 minutes
+  })
+);
 
 app.use(logger("dev"));
 app.use(express.json());

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 var { errorResponse } = require("./utilities/response");
 var { createRateLimiter, createSlowDown } = require("./utilities/responseLimiting");
+var helmet = require("helmet");
 
 //swagger
 const swaggerUi = require("swagger-ui-express");
@@ -37,6 +38,8 @@ var app = express();
 if (process.env.CORS === "true") {
   app.use(cors());
 }
+
+app.use(helmet());
 
 app.use(
   createRateLimiter({

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,4 +1,5 @@
 const auth = require("./authentication");
+const { createRateLimiter, createSlowDown } = require("./security");
 
 module.exports = {
   asyncHandler: require("./asyncHandler"),
@@ -10,4 +11,6 @@ module.exports = {
   validateParamSchema: require("./validateParamSchema"),
   validateCredentials: require("./validateCredentials"),
   ownsEntity: require("./ownsEntity"),
+  createRateLimiter,
+  createSlowDown,
 };

--- a/middleware/security.js
+++ b/middleware/security.js
@@ -1,6 +1,6 @@
 const rateLimit = require("express-rate-limit");
 const slowDown = require("express-slow-down");
-const { errorResponse } = require("./response");
+const { errorResponse } = require("../utilities/response");
 
 /**
  * Creates a rate limiter middleware for Express.js.

--- a/middleware/security.js
+++ b/middleware/security.js
@@ -42,7 +42,6 @@ const createSlowDown = ({ delayAfter, delayMs = 50, windowMs }) => {
     delayMs: (used, req) => {
       return (used - delayAfter) * delayMs;
     },
-    limit: delayAfter,
   });
 };
 

--- a/middleware/security.js
+++ b/middleware/security.js
@@ -35,11 +35,14 @@ const createRateLimiter = ({ max, windowMs, message }) => {
  * @param {number} options.windowMs - Time window in milliseconds for the slowdown.
  * @returns {Function} The slowdown middleware function.
  */
-const createSlowDown = ({ delayAfter, delayMs, windowMs }) => {
+const createSlowDown = ({ delayAfter, delayMs = 50, windowMs }) => {
   return slowDown({
     windowMs,
     delayAfter,
-    delayMs,
+    delayMs: (used, req) => {
+      return (used - delayAfter) * delayMs;
+    },
+    limit: delayAfter,
   });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
         "express-slow-down": "^2.1.0",
+        "helmet": "^8.1.0",
         "http-errors": "^2.0.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
@@ -3549,6 +3550,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "debug": "^4.4.0",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
+        "express-slow-down": "^2.1.0",
         "http-errors": "^2.0.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
@@ -3076,6 +3078,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
+    "node_modules/express-slow-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/express-slow-down/-/express-slow-down-2.1.0.tgz",
+      "integrity": "sha512-tQ/ItTDbGfo+fLS+jxu19vgYOgZk7wyOakuAsnzl8f7HmxG3ynWAoo136+oqB+rqHCk3QyM6VoXL03qA5a4gVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "express-rate-limit": "7"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
     "express-slow-down": "^2.1.0",
+    "helmet": "^8.1.0",
     "http-errors": "^2.0.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "debug": "^4.4.0",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
+    "express-slow-down": "^2.1.0",
     "http-errors": "^2.0.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,6 +3,23 @@ var router = express.Router();
 var { login, register } = require("../controllers/authController");
 var { validateSchema, asyncHandler, validateCredentials } = require("../middleware");
 const { loginSchema, registerSchema, updateUserSchema } = require("../schema");
+var { createRateLimiter, createSlowDown } = require("../utilities/responseLimiting");
+
+router.use(
+  createRateLimiter({
+    max: parseInt(process.env.RATE_LIMIT_MAX) || 15,
+    windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 10 * 60 * 1000, // 10 minutes
+    message: "Too many authentication attempts, please try again in 10 minutes.",
+  })
+);
+
+router.use(
+  createSlowDown({
+    delayAfter: parseInt(process.env.SLOW_DOWN_DELAY_AFTER) || 8,
+    delayMs: parseInt(process.env.SLOW_DOWN_DELAY_MS) || 500,
+    windowMs: parseInt(process.env.SLOW_DOWN_WINDOW_MS) || 5 * 60 * 1000, // 5 minutes
+  })
+);
 
 /**
  * @swagger

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,9 +1,8 @@
 var express = require("express");
 var router = express.Router();
 var { login, register } = require("../controllers/authController");
-var { validateSchema, asyncHandler, validateCredentials } = require("../middleware");
+var { validateSchema, asyncHandler, validateCredentials, createRateLimiter, createSlowDown } = require("../middleware");
 const { loginSchema, registerSchema, updateUserSchema } = require("../schema");
-var { createRateLimiter, createSlowDown } = require("../utilities/responseLimiting");
 
 router.use(
   createRateLimiter({

--- a/utilities/responseLimiting.js
+++ b/utilities/responseLimiting.js
@@ -1,0 +1,49 @@
+const rateLimit = require("express-rate-limit");
+const slowDown = require("express-slow-down");
+const { errorResponse } = require("./response");
+
+/**
+ * Creates a rate limiter middleware for Express.js.
+ * @param {Object} options - Configuration options for the rate limiter.
+ * @param {number} options.max - Maximum number of requests allowed within the window.
+ * @param {number} options.windowMs - Time window in milliseconds for the rate limit.
+ * @param {string} [options.message] - Custom message to return when the limit is exceeded.
+ * @returns {Function} The rate limiter middleware function.
+ */
+const createRateLimiter = ({ max, windowMs, message }) => {
+  return rateLimit({
+    windowMs,
+    max,
+    handler: (req, res) => {
+      return res.status(429).json(
+        errorResponse({
+          statusCode: 429,
+          message: message || "Too many requests, try again later.",
+        })
+      );
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+};
+
+/**
+ * Creates a slowdown middleware for Express.js.
+ * @param {Object} options - Configuration options for the slowdown.
+ * @param {number} options.delayAfter - Number of requests after which to start slowing down.
+ * @param {number} options.delayMs - Delay in milliseconds to apply after the threshold is reached.
+ * @param {number} options.windowMs - Time window in milliseconds for the slowdown.
+ * @returns {Function} The slowdown middleware function.
+ */
+const createSlowDown = ({ delayAfter, delayMs, windowMs }) => {
+  return slowDown({
+    windowMs,
+    delayAfter,
+    delayMs,
+  });
+};
+
+module.exports = {
+  createRateLimiter,
+  createSlowDown,
+};


### PR DESCRIPTION
I've added a global rate limiter with slow down onto all routes. This is calibrated to allow 600 requests every 10minutes with 240 requests in 5 mins resulting in a slow down in response times to try and discourage rapidly hitting the hard cap on requests. I have also added a 15 request limit on the auth route with a slow down after 8 requests, this might need some fine tuning and potentially a little tweaking depending on the endpoint. 

I have also added helmet to the API this is currently using default settings, but this added extra protections once we have the frontend deployed we can test out adding some stricter rules and a limit the cors requests.

I have also limited the size of the JSON we will accept to 100kb more than generous, as we are not allowing file uploads at this time. I have disabled the powered by header too, no need to advertise we are using express to all attackers to narrow in a points of attack.