### PR TITLE
Swagger - rate limiting documentation

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -1,13 +1,32 @@
 /**
  * @swagger
  * components:
- *
  *   securitySchemes:
  *     bearerAuth:
  *       type: http
  *       scheme: bearer
  *       bearerFormat: JWT
- *       description: JWT token for authentication. Format: "Bearer {token}"
+ *   parameters:
+ *     limitParam:
+ *       name: limit
+ *       in: query
+ *       required: false
+ *       description: "Number of items to return (1–100). Defaults to 100."
+ *       schema:
+ *         type: integer
+ *         minimum: 1
+ *         maximum: 100
+ *         default: 100
+ *
+ *     offsetParam:
+ *       name: offset
+ *       in: query
+ *       required: false
+ *       description: "Number of items to skip. Defaults to 0."
+ *       schema:
+ *         type: integer
+ *         minimum: 0
+ *         default: 0
  *
  *   headers:
  *     RateLimitHeaders:
@@ -27,11 +46,10 @@
  *           type: integer
  *         example: 1640995200
  *
- *   schemas:
  * #-------------------------------
  * # Reusable Error Responses
  * #-------------------------------
- *
+ *   schemas:
  *     RateLimitResponse:
  *       type: object
  *       properties:
@@ -40,7 +58,7 @@
  *           example: false
  *         status:
  *           type: string
- *           example: "error"
+ *           example: error
  *         statusCode:
  *           type: integer
  *           example: 429
@@ -51,7 +69,7 @@
  *           type: null
  *           nullable: true
  *           example: null
- *       description: "Global rate limit response (600 requests per 10 minutes)"
+ *       description: Global rate limit response (600 requests per 10 minutes)
  *
  *     ValidationErrorResponse:
  *       type: object
@@ -191,7 +209,7 @@
  *
  *     SimpleSuccessResponse:
  *       type: object
- *       description: "Success response for operations that don't return data"
+ *       description: Success response for operations that don't return data
  *       properties:
  *         success:
  *           type: boolean
@@ -205,35 +223,4 @@
  *         message:
  *           type: string
  *           example: "x deleted successfully"
- */
-
-/**
- * @swagger
- * components:
- *   parameters:
- *
- * #-------------------------------
- * # Reusable operation parameters
- * #-------------------------------
- *
- *   limitParam:
- *     name: limit
- *     in: query
- *     required: false
- *     description: Number of items to return (1–100). Defaults to 100.
- *     schema:
- *       type: integer
- *       minimum: 1
- *       maximum: 100
- *       default: 100
- *
- *     offsetParam:
- *       name: offset
- *       in: query
- *       required: false
- *       description: Number of items to skip. Defaults to 0.
- *       schema:
- *         type: integer
- *         minimum: 0
- *         default: 0
  */

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,11 +1,57 @@
 /**
  * @swagger
  * components:
- *   schemas:
  *
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
+ *       description: JWT token for authentication. Format: "Bearer {token}"
+ *
+ *   headers:
+ *     RateLimitHeaders:
+ *       X-RateLimit-Limit:
+ *         description: The number of allowed requests in the current period
+ *         schema:
+ *           type: integer
+ *         example: 600
+ *       X-RateLimit-Remaining:
+ *         description: The number of remaining requests in the current period
+ *         schema:
+ *           type: integer
+ *         example: 599
+ *       X-RateLimit-Reset:
+ *         description: The time at which the current rate limit window resets (UTC epoch seconds)
+ *         schema:
+ *           type: integer
+ *         example: 1640995200
+ *
+ *   schemas:
  * #-------------------------------
  * # Reusable Error Responses
  * #-------------------------------
+ *
+ *     RateLimitResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *           example: false
+ *         status:
+ *           type: string
+ *           example: "error"
+ *         statusCode:
+ *           type: integer
+ *           example: 429
+ *         message:
+ *           type: string
+ *           example: "Too many requests, please try again later."
+ *         errors:
+ *           type: null
+ *           nullable: true
+ *           example: null
+ *       description: "Global rate limit response (600 requests per 10 minutes)"
  *
  *     ValidationErrorResponse:
  *       type: object

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -24,6 +24,27 @@ router.use(
  * @swagger
  * components:
  *   schemas:
+ *     AuthRateLimitResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *           example: false
+ *         status:
+ *           type: string
+ *           example: "error"
+ *         statusCode:
+ *           type: integer
+ *           example: 429
+ *         message:
+ *           type: string
+ *           example: "Too many authentication attempts, please try again in 10 minutes."
+ *         errors:
+ *           type: null
+ *           nullable: true
+ *           example: null
+ *       description: "Authentication-specific rate limit response (15 requests per 10 minutes)"
+ *
  *     RegisterSchema:
  *       type: object
  *       required:
@@ -135,6 +156,20 @@ router.use(
  *                 message:
  *                   type: string
  *                   example: Welcome to the API
+ *       429:
+ *         description: Too many requests - global rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.get("/", function (req, res, next) {
@@ -181,6 +216,20 @@ router.get("/", function (req, res, next) {
  *               status: bad request
  *               data:
  *                 errors: ["Last name is required", "Password must be at least 8 characters"]
+ *       429:
+ *         description: Too many authentication attempts - auth rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.post("/register", validateSchema(registerSchema), asyncHandler(validateCredentials), asyncHandler(register));
@@ -232,6 +281,20 @@ router.post("/register", validateSchema(registerSchema), asyncHandler(validateCr
  *               status: unauthorized
  *               data:
  *                 errors: ["Invalid email or password"]
+ *       429:
+ *         description: Too many authentication attempts - auth rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.post("/login", validateSchema(loginSchema), asyncHandler(login));

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -24,27 +24,6 @@ router.use(
  * @swagger
  * components:
  *   schemas:
- *     AuthRateLimitResponse:
- *       type: object
- *       properties:
- *         success:
- *           type: boolean
- *           example: false
- *         status:
- *           type: string
- *           example: "error"
- *         statusCode:
- *           type: integer
- *           example: 429
- *         message:
- *           type: string
- *           example: "Too many authentication attempts, please try again in 10 minutes."
- *         errors:
- *           type: null
- *           nullable: true
- *           example: null
- *       description: "Authentication-specific rate limit response (15 requests per 10 minutes)"
- *
  *     RegisterSchema:
  *       type: object
  *       required:
@@ -136,6 +115,27 @@ router.use(
  *               type: string
  *               description: JWT token for authenticated requests
  *               example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJqb2huLmRvZUBleGFtcGxlLmNvbSIsImlhdCI6MTYxNjIzOTAyMn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+ *
+ *     AuthRateLimitResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *           example: false
+ *         status:
+ *           type: string
+ *           example: "error"
+ *         statusCode:
+ *           type: integer
+ *           example: 429
+ *         message:
+ *           type: string
+ *           example: "Too many authentication attempts, please try again in 10 minutes."
+ *         errors:
+ *           type: null
+ *           nullable: true
+ *           example: null
+ *       description: Authentication-specific rate limit response (15 requests per 10 minutes).
  */
 
 /**

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -90,6 +90,20 @@ var commentService = new CommentService(db);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/NotFoundResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.put(
@@ -150,6 +164,20 @@ router.put(
  *               statusCode: 404
  *               message: "Comment not found"
  *               errors: { commentId: 123 }
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.delete(

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -99,7 +99,7 @@ var commentService = new CommentService(db);
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -173,7 +173,7 @@ router.put(
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:

--- a/routes/projectComments.js
+++ b/routes/projectComments.js
@@ -226,6 +226,20 @@ var { createComment, getProjectComments } = require("../controllers/commentContr
  *                   statusCode: 404
  *                   message: "Parent comment not found"
  *                   errors: { parentId: 999 }
+ *       429:
+ *         description: Too many requests - global rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.post(
@@ -267,6 +281,14 @@ router.post(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       429:
+ *         description: Too many requests - global rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Server error
  *         content:

--- a/routes/projectComments.js
+++ b/routes/projectComments.js
@@ -235,7 +235,7 @@ var { createComment, getProjectComments } = require("../controllers/commentContr
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -290,7 +290,7 @@ router.post(
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -328,7 +328,7 @@ var projectComments = require("./projectComments");
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -391,7 +391,7 @@ router.get("/", isLoggedIn, asyncHandler(getAll));
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -450,7 +450,7 @@ router.get("/types", asyncHandler(getAllTypes));
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -499,7 +499,7 @@ router.get("/tombstones", asyncHandler(getAllTombstones));
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -549,7 +549,7 @@ router.get("/:id", isLoggedIn, asyncHandler(getOneId));
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -616,7 +616,7 @@ router.post("/", authenticate, validateSchema(projectSchema), asyncHandler(hasRo
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -693,7 +693,7 @@ router.put(
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -776,7 +776,7 @@ router.delete(
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -856,7 +856,7 @@ router.put(
  *           $ref: '#/components/headers/RateLimitHeaders'
  *
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -248,6 +248,9 @@ var projectComments = require("./projectComments");
  *       This endpoint is publicly accessible and returns metadata for pagination.
  *       A logged in user, it will return true for the userHasVoted field if the user has voted on the project.
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
+ *       - {}
  *     parameters:
  *       - in: query
  *         name: limit
@@ -464,6 +467,9 @@ router.get("/tombstones", asyncHandler(getAllTombstones));
  *   get:
  *     summary: Get project by ID
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
+ *       - {}
  *     parameters:
  *       - in: path
  *         name: id
@@ -514,6 +520,8 @@ router.get("/:id", isLoggedIn, asyncHandler(getOneId));
  *   post:
  *     summary: Create a new project
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -563,6 +571,8 @@ router.post("/", authenticate, validateSchema(projectSchema), asyncHandler(hasRo
  *   put:
  *     summary: Update an existing project
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -637,6 +647,8 @@ router.put(
  *   delete:
  *     summary: Soft delete a project
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -716,6 +728,8 @@ router.delete(
  *       Adds a type (tag) to the specified project. The type should be provided in the request body as a type ID.
  *       Only the project owner or users with the appropriate role can add a type to a project.
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -800,6 +814,8 @@ router.put(
  *       Removes a type (tag) from the specified project. The type should be provided in the request body as a type ID.
  *       Only the project owner or users with the appropriate role can remove a type from a project.
  *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -319,6 +319,20 @@ var projectComments = require("./projectComments");
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 router.get("/", isLoggedIn, asyncHandler(getAll));
 
@@ -368,6 +382,14 @@ router.get("/", isLoggedIn, asyncHandler(getAll));
  *                         type: string
  *                         format: date-time
  *                         example: "2025-05-07T20:30:17.974Z"
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Server error
  *         content:
@@ -419,6 +441,20 @@ router.get("/types", asyncHandler(getAllTypes));
  *                       imageUrl:
  *                         type: string
  *                         example: "/images/tombstone1.png"
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 router.get("/tombstones", asyncHandler(getAllTombstones));
 
@@ -454,6 +490,20 @@ router.get("/tombstones", asyncHandler(getAllTombstones));
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/NotFoundResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.get("/:id", isLoggedIn, asyncHandler(getOneId));
@@ -489,6 +539,21 @@ router.get("/:id", isLoggedIn, asyncHandler(getOneId));
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.post("/", authenticate, validateSchema(projectSchema), asyncHandler(hasRole("user")), asyncHandler(create));
@@ -542,6 +607,14 @@ router.post("/", authenticate, validateSchema(projectSchema), asyncHandler(hasRo
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/NotFoundResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Server error
  *         content:
@@ -611,6 +684,14 @@ router.put(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/NotFoundResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Server error
  *         content:
@@ -686,6 +767,14 @@ router.delete(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ProjectErrorResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Server error
  *         content:
@@ -693,6 +782,15 @@ router.delete(
  *             schema:
  *               $ref: '#/components/schemas/ProjectServerErrorResponse'
  */
+
+router.put(
+  "/:id/type",
+  authenticate,
+  validateSchema(typeIdSchema),
+  asyncHandler(hasRole("user")),
+  asyncHandler(ownsEntity(projectService)),
+  asyncHandler(addType)
+);
 
 /**
  * @swagger
@@ -747,6 +845,16 @@ router.delete(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ProjectNotFoundResponse'
+ *
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *
  *       500:
  *         description: Server error
  *         content:
@@ -754,15 +862,6 @@ router.delete(
  *             schema:
  *               $ref: '#/components/schemas/ProjectServerErrorResponse'
  */
-
-router.put(
-  "/:id/type",
-  authenticate,
-  validateSchema(typeIdSchema),
-  asyncHandler(hasRole("user")),
-  asyncHandler(ownsEntity(projectService)),
-  asyncHandler(addType)
-);
 
 router.delete(
   "/:id/type",

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -539,7 +539,6 @@ router.get("/:id", isLoggedIn, asyncHandler(getOneId));
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/UnauthorizedResponse'
- *
  *       429:
  *         description: Too many requests
  *         content:
@@ -845,7 +844,6 @@ router.put(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ProjectNotFoundResponse'
- *
  *       429:
  *         description: Too many requests
  *         content:
@@ -854,7 +852,6 @@ router.put(
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
- *
  *       500:
  *         description: Internal server error
  *         content:

--- a/routes/users.js
+++ b/routes/users.js
@@ -8,11 +8,6 @@ const { loginSchema, registerSchema, updateUserSchema } = require("../schema");
 /**
  * @swagger
  * components:
- *   securitySchemes:
- *     bearerAuth:
- *       type: http
- *       scheme: bearer
- *       bearerFormat: JWT
  *   schemas:
  *     UserResponse:
  *       type: object
@@ -114,6 +109,20 @@ const { loginSchema, registerSchema, updateUserSchema } = require("../schema");
  *                 message:
  *                   type: string
  *                   example: Welcome to the API
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.get("/", function (req, res, next) {
@@ -162,6 +171,20 @@ router.get("/", function (req, res, next) {
  *               status: unauthorized
  *               data:
  *                 errors: ["Invalid or expired token"]
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.get("/me", asyncHandler(authenticate), asyncHandler(getMe));
@@ -215,6 +238,20 @@ router.get("/me", asyncHandler(authenticate), asyncHandler(getMe));
  *               status: unauthorized
  *               data:
  *                 errors: ["Invalid or expired token"]
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.get("/deleted", asyncHandler(authenticate), asyncHandler(getAllSoftDeleted));
@@ -267,6 +304,20 @@ router.get("/deleted", asyncHandler(authenticate), asyncHandler(getAllSoftDelete
  *               status: fail
  *               data:
  *                 errors: ["User not found"]
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.get("/:id", asyncHandler(getUser));
@@ -332,6 +383,20 @@ router.get("/:id", asyncHandler(getUser));
  *             example:
  *               status: unauthorized
  *               data:
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.put("/me", asyncHandler(authenticate), validateSchema(updateUserSchema), asyncHandler(updateMe));
@@ -368,6 +433,20 @@ router.put("/me", asyncHandler(authenticate), validateSchema(updateUserSchema), 
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+ *       429:
+ *         description: Too many requests
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
+ *       500:
+ *         description: Server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 
 router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));

--- a/routes/users.js
+++ b/routes/users.js
@@ -392,7 +392,7 @@ router.get("/:id", asyncHandler(getUser));
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:
@@ -442,7 +442,7 @@ router.put("/me", asyncHandler(authenticate), validateSchema(updateUserSchema), 
  *         headers:
  *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
- *         description: Server error
+ *         description: Internal server error
  *         content:
  *           application/json:
  *             schema:

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -41,7 +41,8 @@ var { authenticate, asyncHandler } = require("../middleware");
  * /votes/{projectId}/toggle:
  *   post:
  *     summary: Toggle upvote on a project
- *     description: Adds an upvote if the user hasn't upvoted yet, or removes it if they have. Authentication is required.
+ *     description: Adds an upvote if the user hasn't upvoted yet, or removes it if they have.
+ *       Authentication is required. Rate limited to 600 requests per 10 minutes globally.
  *     tags: [Votes]
  *     security:
  *       - bearerAuth: []
@@ -93,7 +94,14 @@ var { authenticate, asyncHandler } = require("../middleware");
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ProjectNotFoundResponse' #notFoundResponse
- *
+ *       429:
+ *         description: Too many requests - global rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Internal server error
  *         content:

--- a/swagger.js
+++ b/swagger.js
@@ -25,7 +25,6 @@ const options = {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
   },
   apis: ["./routes/*.js", "./docs/*.js"], // legg inn din path her
 };


### PR DESCRIPTION
- Moved bearerAuth security scheme to shared docs
- Added rate limiting responses (429) to all endpoints
- Added server error responses (500) to all endpoints
- Added global rate limit response in shared docs and auth-specific rate limits response in auth route.
- Created reusable headers component for rate limit headers
- Moved project put /:id/type so it's directly underneath the correct swagger docs
