### PR TITLE
Split UserService.getOneId from full profile loading

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -47,7 +47,7 @@ async function getMe(req, res, next) {
 async function updateMe(req, res, next) {
   const id = req.user.id;
 
-  if (Object.keys(req.body).length === 0) {
+  if (!req.body || Object.keys(req.body).length === 0) {
     throw createError({
       statusCode: 400,
       message: "At least one field must be provided for update",

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -6,7 +6,7 @@ const { createError, successResponse } = require("../utilities");
 //This for getting the user based of Id.
 async function getUser(req, res, next) {
   const id = req.params.id;
-  const user = await userService.getOneId(id);
+  const user = await userService.getProfile(id);
 
   if (!user) {
     throw createError({
@@ -26,7 +26,7 @@ async function getUser(req, res, next) {
 
 async function getMe(req, res, next) {
   const id = req.user.id;
-  const user = await userService.getOneId(id, { isOwner: true });
+  const user = await userService.getProfile(id, { isOwner: true });
 
   if (!user) {
     throw createError({

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -54,14 +54,14 @@ async function updateMe(req, res, next) {
     });
   }
 
-  const user = await userService.getOneId(id);
-  if (!user) {
+  const updatedUser = await userService.update(id, req.body);
+
+  if (!updatedUser) {
     throw createError({
       statusCode: 404,
       message: "User not found",
     });
   }
-  const updatedUser = await userService.update(id, req.body);
 
   res.status(200).json(
     successResponse({

--- a/schema/passwordSchema.js
+++ b/schema/passwordSchema.js
@@ -7,8 +7,8 @@ const updatePasswordSchema = yup
       .string()
       .min(8, "Password must be at least 8 characters")
       .matches(
-        /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^\w\s]).{8,}$/,
-        "Password must be at least 8 characters and contain at least one uppercase letter, one lowercase letter, one number, and one special character"
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/,
+        "Password must be at least 8 characters and contain at least one uppercase letter, one lowercase letter and one number"
       )
       .required("New password is required"),
     confirmPassword: yup
@@ -18,8 +18,5 @@ const updatePasswordSchema = yup
   })
   .strict()
   .noUnknown(true, "Unknown field in request body");
-
-// Optional: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/
-// 8 char, at least one uppercase letter, one lowercase letter, one number
 
 module.exports = { updatePasswordSchema };

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -15,7 +15,7 @@ class UserService {
   async getAll() {
     return this.User.findAll({
       include: [{ model: this.Role }],
-      attributes: { exclude: ["encryptedPassword", "salt", "roleId"] },
+      attributes: { exclude: ["hashedPassword", "salt", "roleId"] },
     });
   }
 
@@ -34,7 +34,7 @@ class UserService {
     return this.User.findOne({
       where: { username },
       include: [{ model: this.Role }],
-      attributes: { exclude: ["encryptedPassword", "salt", "roleId"] },
+      attributes: { exclude: ["hashedPassword", "salt", "roleId"] },
     });
   }
 

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -46,6 +46,17 @@ class UserService {
     });
 
     if (!user) return null;
+    return sanitizeUser(user);
+  }
+
+  async getProfile(userId) {
+    const user = await this.User.findOne({
+      where: { id: userId },
+      include: [{ model: this.Role }],
+      attributes: { exclude: ["hashedPassword", "salt", "roleId"] },
+    });
+
+    if (!user) return null;
 
     const sanitizedUser = sanitizeUser(user);
     const { count, rows } = await this.projectService.getAll(10, 0, {

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -49,7 +49,7 @@ class UserService {
     return sanitizeUser(user);
   }
 
-  async getProfile(userId) {
+  async getProfile(userId, options = {}) {
     const user = await this.User.findOne({
       where: { id: userId },
       include: [{ model: this.Role }],
@@ -58,7 +58,7 @@ class UserService {
 
     if (!user) return null;
 
-    const sanitizedUser = sanitizeUser(user);
+    const sanitizedUser = sanitizeUser(user, options);
     const { count, rows } = await this.projectService.getAll(10, 0, {
       userId,
       currentUserId: null,


### PR DESCRIPTION
getOneId loads projects and stats even when callers only need the user. Middleware hits the DB for a full profile just to check role.

Changed:

- getOneId now returns just the user
- New getProfile returns user + projects + stats (old getOneId)
- Updated controllers to call the right method
- Fixed updateMe empty body check, removed extra DB query
- passwordSchema now matches registerSchema