### PR TITLE
fix: db-init closes shared connection pool on server startup

### DIFF
--- a/scripts/cli-db-init.js
+++ b/scripts/cli-db-init.js
@@ -1,8 +1,9 @@
-const { initDb } = require("./db-init");
+const { initDb, closeDb } = require("./db-init");
 
 async function run() {
   try {
     await initDb();
+    await closeDb();
     console.log("Database initialization successful.");
     process.exit(0); // Success exit code
   } catch (err) {

--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -18,10 +18,11 @@ async function initDb() {
 
   // Verify crud connection works (optional but useful)
   await db.sequelize.authenticate();
+}
 
-  // Cleanup so CI doesn't hang on open handles
+async function closeDb() {
   await adminDb.sequelize.close();
   await db.sequelize.close();
 }
 
-module.exports = { initDb };
+module.exports = { initDb, closeDb };


### PR DESCRIPTION
 ### ISSUE:  '
Got errorcode 500 and "message": "ConnectionManager.getConnection was called after the connection manager was closed!" when testing endpoints with postman.
 
> initDb() called db.sequelize.close() unconditionally. Since db is a
singleton, this killed the connection pool for the entire process.

So every request after startup hit the 500.

 ### FIX:
- Extracted closeDb() from initDb()
- cli-db-init.js now calls closeDb() explicitly after initDb()
- app.js calls initDb() only (no pool teardown)