### PR TITLE
 feat/fix: validation schemas and add auth schemas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,14 +21,15 @@ OUTPUT_SWAGGER=false
 # JWT secret key
 JWT_SECRET= Secret_Sauce
 
-# NodeMailer Development - Ethereal (nodemailer's test account)
+# NodeMailer Development - Ethereal (nodemailer test account)
 SMTP_HOST=smtp.ethereal.email
 SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_USER=<your-ethereal-user>
 SMTP_PASS=<your-ethereal-pass>
-EMAIL_FROM=noreply@productivity-graveyard.dev
-APP_URL=http://localhost:3000
+EMAIL_FROM_NAME=Productivity Graveyard
+EMAIL_FROM_ADDRESS=noreply@productivity-graveyard.dev
+FRONTEND_URL=http://localhost:3000
 
 
 

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ SSL_REQUIRED=false
 # Not needed for local dev, defaults to 5432 for postgres
 # DB_PORT=5432
 
-#Express server
+# Express server
 PORT=3000
 CORS=true
 ENVIRONMENT=development
@@ -20,6 +20,15 @@ OUTPUT_SWAGGER=false
 
 # JWT secret key
 JWT_SECRET= Secret_Sauce
+
+# NodeMailer Development - Ethereal (nodemailer's test account)
+SMTP_HOST=smtp.ethereal.email
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=<your-ethereal-user>
+SMTP_PASS=<your-ethereal-pass>
+EMAIL_FROM=noreply@productivity-graveyard.dev
+APP_URL=http://localhost:3000
 
 
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -6,7 +6,7 @@ const { createError, successResponse } = require("../utilities");
 //This for getting the user based of Id.
 async function getUser(req, res, next) {
   const id = req.params.id;
-  const user = await userService.getProfile(id);
+  const user = await userService.getProfile(id, { currentUserId: req.user?.id ?? null });
 
   if (!user) {
     throw createError({
@@ -26,7 +26,7 @@ async function getUser(req, res, next) {
 
 async function getMe(req, res, next) {
   const id = req.user.id;
-  const user = await userService.getProfile(id, { isOwner: true });
+  const user = await userService.getProfile(id, { isOwner: true, currentUserId: req.user.id });
 
   if (!user) {
     throw createError({

--- a/models/Token.js
+++ b/models/Token.js
@@ -1,0 +1,50 @@
+module.exports = (sequelize, Sequelize) => {
+  const { DataTypes } = Sequelize;
+
+  const Token = sequelize.define(
+    "Token",
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      type: {
+        type: DataTypes.ENUM("email_verification", "email_change", "password_reset"),
+        allowNull: false,
+      },
+      tokenHash: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      expiresAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      usedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        defaultValue: null,
+      },
+    },
+    {
+      timestamps: true,
+      tableName: "Tokens",
+      paranoid: false,
+      indexes: [{ fields: ["tokenHash"] }, { fields: ["userId", "type"] }],
+    }
+  );
+
+  Token.associate = (models) => {
+    Token.belongsTo(models.User, {
+      foreignKey: "userId",
+      onDelete: "CASCADE",
+    });
+  };
+
+  return Token;
+};

--- a/models/User.js
+++ b/models/User.js
@@ -45,12 +45,10 @@ module.exports = (sequelize, Sequelize) => {
       hashedPassword: {
         type: DataTypes.STRING,
         allowNull: false,
-        comment: "Bcrypt-hashed password",
       },
       salt: {
         type: DataTypes.STRING,
         allowNull: false,
-        comment: "Bcrypt salt for password hashing",
       },
       isEmailVerified: {
         type: DataTypes.BOOLEAN,

--- a/models/User.js
+++ b/models/User.js
@@ -52,6 +52,11 @@ module.exports = (sequelize, Sequelize) => {
         allowNull: false,
         comment: "Bcrypt salt for password hashing",
       },
+      isEmailVerified: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
       avatarUrl: {
         type: DataTypes.STRING,
         allowNull: true,

--- a/models/User.js
+++ b/models/User.js
@@ -96,6 +96,10 @@ module.exports = (sequelize, Sequelize) => {
       foreignKey: "userId",
       onDelete: "CASCADE",
     });
+    User.hasMany(models.Token, {
+      foreignKey: "userId",
+      onDelete: "CASCADE",
+    });
     User.belongsToMany(models.Achievement, {
       through: "UserAchievements",
       foreignKey: "userId",

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,6 +1,6 @@
 var express = require("express");
 var router = express.Router();
-const { getUser, updateMe, getMe, softDeletedUser, getAllSoftDeleted } = require("../controllers/userController");
+const { getUser, updateMe, getMe, softDeletedUser } = require("../controllers/userController");
 const { authenticate, hasRole, isAdmin, isSelfOrAdmin } = require("../middleware/authentication");
 var { validateSchema, asyncHandler, validateCredentials } = require("../middleware");
 const { loginSchema, registerSchema, updateUserSchema } = require("../schema");
@@ -13,7 +13,6 @@ router.get("/me", asyncHandler(authenticate), asyncHandler(getMe));
 router.get("/:id", asyncHandler(getUser));
 router.put("/me", asyncHandler(authenticate), validateSchema(updateUserSchema), asyncHandler(updateMe));
 router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
-/*router.get("/deleted", asyncHandler(authenticate), asyncHandler(isAdmin), asyncHandler(getAllSoftDeleted));*/
 
 /**
  * @swagger
@@ -92,18 +91,18 @@ router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
  *       properties:
  *         firstName:
  *           type: string
- *           maxLength: 15
+ *           maxLength: 30
  *           minLength: 2
  *           example: John
  *         lastName:
  *           type: string
- *           maxLength: 15
+ *           maxLength: 30
  *           minLength: 2
  *           example: Doe
  *         username:
  *           type: string
  *           minLength: 3
- *           maxLength: 20
+ *           maxLength: 30
  *           pattern: "^[a-zA-Z0-9_]+$"
  *           example: johndoe123
  *         bio:

--- a/schema/emailSchema.js
+++ b/schema/emailSchema.js
@@ -1,0 +1,10 @@
+const yup = require("yup");
+
+const verifyEmailSchema = yup
+  .object({
+    token: yup.string().required("Verification token is required"),
+  })
+  .strict()
+  .noUnknown(true, "Unknown field in request body");
+
+module.exports = { verifyEmailSchema };

--- a/schema/emailSchema.js
+++ b/schema/emailSchema.js
@@ -7,4 +7,8 @@ const verifyEmailSchema = yup
   .strict()
   .noUnknown(true, "Unknown field in request body");
 
-module.exports = { verifyEmailSchema };
+const resetEmailSchema = yup.object({
+  email: yup.string().email("Please provide a valid email").required("New email is required"),
+});
+
+module.exports = { verifyEmailSchema, resetEmailSchema };

--- a/schema/emailSchema.js
+++ b/schema/emailSchema.js
@@ -2,13 +2,19 @@ const yup = require("yup");
 
 const verifyEmailSchema = yup
   .object({
-    token: yup.string().required("Verification token is required"),
+    token: yup
+      .string()
+      .matches(/^[a-f0-9]{64}$/, "Invalid token format")
+      .required("Verification token is required"),
   })
   .strict()
   .noUnknown(true, "Unknown field in request body");
 
-const resetEmailSchema = yup.object({
-  email: yup.string().email("Please provide a valid email").required("New email is required"),
-});
+const emailSchema = yup
+  .object({
+    email: yup.string().email("Please provide a valid email").required("Email is required"),
+  })
+  .strict()
+  .noUnknown(true, "Unknown field in request body");
 
-module.exports = { verifyEmailSchema, resetEmailSchema };
+module.exports = { verifyEmailSchema, emailSchema };

--- a/schema/index.js
+++ b/schema/index.js
@@ -4,6 +4,8 @@ const { updateUserSchema } = require("./updateUserSchema");
 const { projectIdSchema, commentIdSchema, uuidSchema } = require("./params");
 const { projectSchema, projectUpdateSchema, typeIdSchema } = require("./projectSchema");
 const { createCommentSchema, updateCommentSchema } = require("./commentSchema");
+const { updatePasswordSchema, resetPasswordSchema, forgotPasswordSchema } = require("./passwordSchema");
+const { verifyEmailSchema, resetEmailSchema } = require("./emailSchema");
 module.exports = {
   loginSchema,
   registerSchema,
@@ -16,4 +18,9 @@ module.exports = {
   projectSchema,
   projectUpdateSchema,
   typeIdSchema,
+  updatePasswordSchema,
+  resetPasswordSchema,
+  forgotPasswordSchema,
+  verifyEmailSchema,
+  resetEmailSchema,
 };

--- a/schema/index.js
+++ b/schema/index.js
@@ -4,8 +4,8 @@ const { updateUserSchema } = require("./updateUserSchema");
 const { projectIdSchema, commentIdSchema, uuidSchema } = require("./params");
 const { projectSchema, projectUpdateSchema, typeIdSchema } = require("./projectSchema");
 const { createCommentSchema, updateCommentSchema } = require("./commentSchema");
-const { updatePasswordSchema, resetPasswordSchema, forgotPasswordSchema } = require("./passwordSchema");
-const { verifyEmailSchema, resetEmailSchema } = require("./emailSchema");
+const { updatePasswordSchema, resetPasswordSchema } = require("./passwordSchema");
+const { verifyEmailSchema, emailSchema } = require("./emailSchema");
 module.exports = {
   loginSchema,
   registerSchema,
@@ -20,7 +20,6 @@ module.exports = {
   typeIdSchema,
   updatePasswordSchema,
   resetPasswordSchema,
-  forgotPasswordSchema,
   verifyEmailSchema,
-  resetEmailSchema,
+  emailSchema,
 };

--- a/schema/passwordSchema.js
+++ b/schema/passwordSchema.js
@@ -25,4 +25,4 @@ const resetPasswordSchema = yup
   .strict()
   .noUnknown(true, "Unknown field in request body");
 
-module.exports = { updatePasswordSchema, resetPasswordSchema, forgotPasswordSchema };
+module.exports = { updatePasswordSchema, resetPasswordSchema };

--- a/schema/passwordSchema.js
+++ b/schema/passwordSchema.js
@@ -21,7 +21,13 @@ const updatePasswordSchema = yup
   .noUnknown(true, "Unknown field in request body");
 
 const resetPasswordSchema = yup
-  .object({ token: yup.string().required("Reset token is required"), ...newPasswordFields })
+  .object({
+    token: yup
+      .string()
+      .matches(/^[a-f0-9]{64}$/, "Invalid token format")
+      .required("Reset token is required"),
+    ...newPasswordFields,
+  })
   .strict()
   .noUnknown(true, "Unknown field in request body");
 

--- a/schema/passwordSchema.js
+++ b/schema/passwordSchema.js
@@ -25,11 +25,4 @@ const resetPasswordSchema = yup
   .strict()
   .noUnknown(true, "Unknown field in request body");
 
-const forgotPasswordSchema = yup
-  .object({
-    email: yup.string().email("Please provide a valid email").required("Email is required"),
-  })
-  .strict()
-  .noUnknown(true, "Unknown field in request body");
-
 module.exports = { updatePasswordSchema, resetPasswordSchema, forgotPasswordSchema };

--- a/schema/passwordSchema.js
+++ b/schema/passwordSchema.js
@@ -1,22 +1,35 @@
 const yup = require("yup");
 
+const newPasswordFields = {
+  newPassword: yup
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .max(64, "Password must be at most 64 characters")
+    .matches(/[a-z]/, "Password must contain at least one lowercase letter")
+    .matches(/[A-Z]/, "Password must contain at least one uppercase letter")
+    .matches(/[0-9]/, "Password must contain at least one number")
+    .required("New password is required"),
+  confirmPassword: yup
+    .string()
+    .oneOf([yup.ref("newPassword")], "Passwords must match")
+    .required("Password confirmation is required"),
+};
+
 const updatePasswordSchema = yup
+  .object({ currentPassword: yup.string().required("Current password is required"), ...newPasswordFields })
+  .strict()
+  .noUnknown(true, "Unknown field in request body");
+
+const resetPasswordSchema = yup
+  .object({ token: yup.string().required("Reset token is required"), ...newPasswordFields })
+  .strict()
+  .noUnknown(true, "Unknown field in request body");
+
+const forgotPasswordSchema = yup
   .object({
-    currentPassword: yup.string().required("Current password is required"),
-    newPassword: yup
-      .string()
-      .min(8, "Password must be at least 8 characters")
-      .matches(
-        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/,
-        "Password must be at least 8 characters and contain at least one uppercase letter, one lowercase letter and one number"
-      )
-      .required("New password is required"),
-    confirmPassword: yup
-      .string()
-      .oneOf([yup.ref("newPassword")], "Passwords must match")
-      .required("Password confirmation is required"),
+    email: yup.string().email("Please provide a valid email").required("Email is required"),
   })
   .strict()
   .noUnknown(true, "Unknown field in request body");
 
-module.exports = { updatePasswordSchema };
+module.exports = { updatePasswordSchema, resetPasswordSchema, forgotPasswordSchema };

--- a/schema/registerSchema.js
+++ b/schema/registerSchema.js
@@ -1,9 +1,21 @@
 const yup = require("yup");
 
 const registerSchema = yup.object({
-  firstName: yup.string().required("First name is required").max(15, "First name must be at most 15 characters"),
-  lastName: yup.string().required("Last name is required").max(15, "Last name must be at most 15 characters"),
-  username: yup.string().required("Username is required").max(15, "Username must be at most 15 characters"),
+  firstName: yup
+    .string()
+    .required("First name is required")
+    .min(2, "First name must be at least 2 characters")
+    .max(30, "First name must be at most 30 characters"),
+  lastName: yup
+    .string()
+    .required("Last name is required")
+    .min(2, "Last name must be at least 2 characters")
+    .max(30, "Last name must be at most 30 characters"),
+  username: yup
+    .string()
+    .required("Username is required")
+    .min(3, "Username must be at least 3 characters")
+    .max(30, "Username must be at most 30 characters"),
   email: yup.string().email("Please provide a valid email").required("Email is required"),
   password: yup
     .string()
@@ -11,7 +23,7 @@ const registerSchema = yup.object({
     .matches(/[a-z]/, "Password must contain at least one lowercase letter")
     .matches(/[A-Z]/, "Password must contain at least one uppercase letter")
     .matches(/[0-9]/, "Password must contain at least one number")
-    .max(20, "Password must be at most 20 characters")
+    .max(64, "Password must be at most 64 characters")
     .required("Password is required"),
 });
 

--- a/schema/resetEmailSchema.js
+++ b/schema/resetEmailSchema.js
@@ -1,7 +1,0 @@
-const yup = require("yup");
-
-const resetEmailSchema = yup.object({
-  email: yup.string().email("Please provide a valid email").required("New email is required"),
-});
-
-module.exports = { resetEmailSchema };

--- a/schema/updateUserSchema.js
+++ b/schema/updateUserSchema.js
@@ -4,18 +4,18 @@ const updateUserSchema = yup
   .object({
     firstName: yup
       .string()
-      .max(15, "First name must be at most 15 characters")
+      .max(30, "First name must be at most 30 characters")
       .min(2, "First name must be at least 2 characters")
       .optional(),
     lastName: yup
       .string()
-      .max(15, "Last name must be at most 15 characters")
+      .max(30, "Last name must be at most 30 characters")
       .min(2, "Last name must be at least 2 characters")
       .optional(),
     username: yup
       .string()
       .min(3, "Username must be at least 3 characters")
-      .max(20, "Username must be at most 20 characters")
+      .max(30, "Username must be at most 30 characters")
       .matches(/^[a-zA-Z0-9_]+$/, "Username can only contain letters, numbers, and underscores")
       .optional(),
     bio: yup.string().max(500, "Bio must be at most 500 characters").optional(),

--- a/seeder/seed.js
+++ b/seeder/seed.js
@@ -66,6 +66,7 @@ async function usersSeed(db) {
           username: dummyUsers[i].username,
           email: dummyUsers[i].email,
           salt: salt,
+          isEmailVerified: false,
           hashedPassword: hashedPassword,
         },
         { transaction }

--- a/seeder/users.json
+++ b/seeder/users.json
@@ -5,6 +5,7 @@
     "username": "admin_user",
     "email": "ada.admin@example.com",
     "password": "admin123",
+    "isEmailVerified ": "false",
     "bio": "Can override your code and your will to live. Handles bans with a smile.",
     "roleId": 3,
     "achievement": [1]
@@ -15,6 +16,7 @@
     "username": "jake_the_junior",
     "email": "jake@example.com",
     "password": "user123",
+    "isEmailVerified ": "false",
     "bio": "Junior dev. Broke production once, now writes poetry in commit messages.",
     "roleId": 1,
     "achievement": [1]
@@ -25,6 +27,7 @@
     "username": "nina_null",
     "email": "nina@example.com",
     "password": "user123",
+    "isEmailVerified ": "false",
     "bio": "Frontend fan. Has 42 design systems and still hates all buttons.",
     "roleId": 1,
     "achievement": [1]
@@ -35,6 +38,7 @@
     "username": "trev_dev",
     "email": "trev@example.com",
     "password": "user123",
+    "isEmailVerified ": "false",
     "bio": "Backend builder. Once Dockerized his breakfast. Loves indexes and chili.",
     "roleId": 1,
     "achievement": [1]
@@ -55,6 +59,7 @@
     "username": "bruno_burnout",
     "email": "bruno@example.com",
     "password": "user123",
+    "isEmailVerified ": "false",
     "bio": "Former startup hero turned side-project ghost. Maintainer of 0 repos.",
     "roleId": 1,
     "achievement": [1]
@@ -65,6 +70,7 @@
     "username": "sasha_scopecreep",
     "email": "sasha@example.com",
     "password": "user123",
+    "isEmailVerified ": "false",
     "bio": "Started a to-do app. It now powers a space agency. Easily distracted.",
     "roleId": 1,
     "achievement": [1]

--- a/seeder/users.json
+++ b/seeder/users.json
@@ -5,7 +5,7 @@
     "username": "admin_user",
     "email": "ada.admin@example.com",
     "password": "admin123",
-    "isEmailVerified ": "false",
+    "isEmailVerified ": false,
     "bio": "Can override your code and your will to live. Handles bans with a smile.",
     "roleId": 3,
     "achievement": [1]
@@ -16,7 +16,7 @@
     "username": "jake_the_junior",
     "email": "jake@example.com",
     "password": "user123",
-    "isEmailVerified ": "false",
+    "isEmailVerified ": false,
     "bio": "Junior dev. Broke production once, now writes poetry in commit messages.",
     "roleId": 1,
     "achievement": [1]
@@ -27,7 +27,7 @@
     "username": "nina_null",
     "email": "nina@example.com",
     "password": "user123",
-    "isEmailVerified ": "false",
+    "isEmailVerified ": false,
     "bio": "Frontend fan. Has 42 design systems and still hates all buttons.",
     "roleId": 1,
     "achievement": [1]
@@ -38,7 +38,7 @@
     "username": "trev_dev",
     "email": "trev@example.com",
     "password": "user123",
-    "isEmailVerified ": "false",
+    "isEmailVerified ": false,
     "bio": "Backend builder. Once Dockerized his breakfast. Loves indexes and chili.",
     "roleId": 1,
     "achievement": [1]
@@ -49,6 +49,7 @@
     "username": "moderator_ally",
     "email": "alice.smith@example.com",
     "password": "mod123",
+    "isEmailVerified ": false,
     "bio": "Moderator with an iron fist and CSS-laced gloves. Speaks fluent regex.",
     "roleId": 2,
     "achievement": [1]
@@ -59,7 +60,7 @@
     "username": "bruno_burnout",
     "email": "bruno@example.com",
     "password": "user123",
-    "isEmailVerified ": "false",
+    "isEmailVerified ": false,
     "bio": "Former startup hero turned side-project ghost. Maintainer of 0 repos.",
     "roleId": 1,
     "achievement": [1]
@@ -70,7 +71,7 @@
     "username": "sasha_scopecreep",
     "email": "sasha@example.com",
     "password": "user123",
-    "isEmailVerified ": "false",
+    "isEmailVerified ": false,
     "bio": "Started a to-do app. It now powers a space agency. Easily distracted.",
     "roleId": 1,
     "achievement": [1]

--- a/services/EmailService.js
+++ b/services/EmailService.js
@@ -1,0 +1,59 @@
+const nodemailer = require("nodemailer");
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT, 10) || 587,
+  secure: process.env.SMTP_SECURE === "true",
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+const getFrom = () => `"${process.env.EMAIL_FROM_NAME}" <${process.env.EMAIL_FROM_ADDRESS}>`;
+
+async function sendVerificationEmail(to, token) {
+  const baseUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+  const verificationUrl = `${baseUrl}/auth/verify-email?token=${token}`;
+
+  const info = await transporter.sendMail({
+    from: getFrom(),
+    to,
+    subject: "Confirm your email address",
+    html: `
+      <h2>Welcome to Productivity Graveyard!</h2>
+      <p>Please confirm your email address by clicking the link below:</p>
+      <a href="${verificationUrl}">${verificationUrl}</a>
+      <p>This link is valid for 24 hours.</p>
+      <p>If you did not create an account, you can safely ignore this email.</p>
+    `,
+  });
+
+  if (process.env.ENVIRONMENT === "development") {
+    console.log("Preview URL:", nodemailer.getTestMessageUrl(info));
+  }
+}
+
+async function sendPasswordResetEmail(to, token) {
+  const baseUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+  const resetUrl = `${baseUrl}/auth/reset-password?token=${token}`;
+
+  const info = await transporter.sendMail({
+    from: getFrom(),
+    to,
+    subject: "Reset your password",
+    html: `
+      <h2>Forgot your password?</h2>
+      <p>Click the link below to reset your password:</p>
+      <a href="${resetUrl}">${resetUrl}</a>
+      <p>This link is valid for 30 minutes and can only be used once.</p>
+      <p>If you didn't request this, please ignore this email. Your password will remain unchanged.</p>
+    `,
+  });
+
+  if (process.env.ENVIRONMENT === "development") {
+    console.log("Preview URL:", nodemailer.getTestMessageUrl(info));
+  }
+}
+
+module.exports = { sendVerificationEmail, sendPasswordResetEmail };

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -50,6 +50,8 @@ class UserService {
   }
 
   async getProfile(userId, options = {}) {
+    const { currentUserId = null, ...sanitizeOptions } = options;
+
     const user = await this.User.findOne({
       where: { id: userId },
       include: [{ model: this.Role }],
@@ -58,11 +60,12 @@ class UserService {
 
     if (!user) return null;
 
-    const sanitizedUser = sanitizeUser(user, options);
+    const sanitizedUser = sanitizeUser(user, sanitizeOptions);
     const { count, rows } = await this.projectService.getAll(10, 0, {
       userId,
-      currentUserId: null,
+      currentUserId,
     });
+
     const stats = await this.statsService.getUserStats(userId);
 
     sanitizedUser.projects = {

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -49,7 +49,7 @@ class UserService {
     return sanitizeUser(user);
   }
 
-  async getProfile(userId) {
+  async getProfile(userId, options = {}) {
     const user = await this.User.findOne({
       where: { id: userId },
       include: [{ model: this.Role }],
@@ -58,7 +58,7 @@ class UserService {
 
     if (!user) return null;
 
-    const sanitizedUser = sanitizeUser(user);
+    const sanitizedUser = sanitizeUser(user, options);
     const { count, rows } = await this.projectService.getAll(10, 0, {
       userId,
       currentUserId: null,

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -379,6 +379,7 @@ describe("Users API - Complete Test Suite", () => {
         expect(res.body.data.id).toBe(user.id);
         expect(res.body.data.username).toBeDefined();
         expect(res.body.data.role).toBe("user");
+        expect(res.body.data.isEmailVerified).toBe(false);
       });
 
       it("should return owner-specific fields for current user", async () => {

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -175,23 +175,28 @@ describe("Users API - Complete Test Suite", () => {
       it("should reject too long lastName", async () => {
         const invalidData = {
           firstName: "John",
-          lastName: `DoeVeryLongname${Date.now()}`,
+          lastName: "DoeVeryLongLastNameThatExceedsLimit",
           username,
           email,
           password,
         };
-        await expect(registerSchema.validate(invalidData)).rejects.toThrow("Last name must be at most 15 characters");
+        await expect(registerSchema.validate(invalidData)).rejects.toThrow("Last name must be at most 30 characters");
       });
 
       it("should reject too long username", async () => {
         const invalidData = {
           firstName: "John",
           lastName: "Doe",
-          username: `johnuser${Date.now()}`,
+          username: "thisusernameiswaytoolongtobevalid",
           email,
           password,
         };
-        await expect(registerSchema.validate(invalidData)).rejects.toThrow("Username must be at most 15 characters");
+        await expect(registerSchema.validate(invalidData)).rejects.toThrow("Username must be at most 30 characters");
+      });
+
+      it("should reject firstName too short", async () => {
+        const invalidData = { firstName: "J", lastName: "Doe", username, email, password };
+        await expect(registerSchema.validate(invalidData)).rejects.toThrow("First name must be at least 2 characters");
       });
 
       it("should reject too long password", async () => {
@@ -200,9 +205,9 @@ describe("Users API - Complete Test Suite", () => {
           lastName: "Doe",
           username,
           email,
-          password: `ThisisaveryLongPassword13!`,
+          password: "ThisIsAVeryLongPasswordThatExceedsTheSixtyFourCharacterLimitABC123",
         };
-        await expect(registerSchema.validate(invalidData)).rejects.toThrow("Password must be at most 20 characters");
+        await expect(registerSchema.validate(invalidData)).rejects.toThrow("Password must be at most 64 characters");
       });
     });
 

--- a/utilities/hashing.js
+++ b/utilities/hashing.js
@@ -33,4 +33,14 @@ async function verifyPassword(inputPassword, storedSalt, storedPassword) {
   }
 }
 
-module.exports = { hashPassword, verifyPassword };
+function generateToken() {
+  const plaintext = crypto.randomBytes(32).toString("hex");
+  const hash = crypto.createHash("sha256").update(plaintext).digest("hex");
+  return { plaintext, hash };
+}
+
+function hashToken(plaintext) {
+  return crypto.createHash("sha256").update(plaintext).digest("hex");
+}
+
+module.exports = { hashPassword, verifyPassword, generateToken, hashToken };

--- a/utilities/sanitizeUser.js
+++ b/utilities/sanitizeUser.js
@@ -1,5 +1,5 @@
 function sanitizeUser(user, options = {}) {
-  const { isOwner = false, isAdmin = false, includeId = false } = options;
+  const { isOwner = false, isAdmin = false } = options;
 
   const base = {
     id: user.id,
@@ -8,14 +8,8 @@ function sanitizeUser(user, options = {}) {
     bio: user.bio,
     avatarUrl: user.avatarUrl,
     role: user.Role?.name || "user",
-    isEmailVerified: user.isEmailVerified,
     createdAt: user.createdAt,
   };
-
-  if (includeId) {
-    // QUESTION: this is not needed as base now has user.id. Permission to remove? (unless we change base again?)
-    base.id = user.id;
-  }
 
   if (isOwner || isAdmin) {
     return {
@@ -23,6 +17,7 @@ function sanitizeUser(user, options = {}) {
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,
+      isEmailVerified: user.isEmailVerified,
     };
   }
 

--- a/utilities/sanitizeUser.js
+++ b/utilities/sanitizeUser.js
@@ -8,10 +8,12 @@ function sanitizeUser(user, options = {}) {
     bio: user.bio,
     avatarUrl: user.avatarUrl,
     role: user.Role?.name || "user",
+    isEmailVerified: user.isEmailVerified,
     createdAt: user.createdAt,
   };
 
   if (includeId) {
+    // QUESTION: this is not needed as base now has user.id. Permission to remove? (unless we change base again?)
     base.id = user.id;
   }
 


### PR DESCRIPTION
### Changes

- `èmailSchema` - new `verifyEmailSchema` , old `resetEmailSchema` moved to same file and old `resetEmailSchema.js` deleted.
- `passwordSchema.js` -  shared `newPasswordFields` , `updatePasswordSchema`, `resetPasswordSchema`, `forgotPasswordSchema`
- `registerSchema` - password max length raised to 64, name/username max length raised to 30, added `min()` on names.
- `updateUserSchema` - name/username max length raised to 30.
- `schema/index.js` - exports new schemas.
- Updated 3 tests to match new limits (lastName, username, password max) and added test for  min length on register.
- `routes/users` - `UpdateUserSchema` (swagger.jsdocs) updated to reflect new min/max values. + removed admin route and import