### PR TITLE
Token cooldown & daily limits for email endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@ app.use((err, req, res, next) => {
   if (statusCode >= 500 && process.env.LOG_ERRORS === "true") {
     console.error("Server Error:", err);
   }
-  if (err.retryAfter) {
+  if (statusCode === 429 && err.retryAfter) {
     res.set("Retry-After", String(err.retryAfter));
   }
   const response = errorResponse({

--- a/app.js
+++ b/app.js
@@ -103,6 +103,9 @@ app.use((err, req, res, next) => {
   if (statusCode >= 500 && process.env.LOG_ERRORS === "true") {
     console.error("Server Error:", err);
   }
+  if (err.retryAfter) {
+    res.set("Retry-After", String(err.retryAfter));
+  }
   const response = errorResponse({
     message,
     status,

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -43,7 +43,7 @@ async function register(req, res) {
 async function login(req, res) {
   const { email, password } = req.body;
 
-  const user = await userService.getOneEmail(email, false, false);
+  const user = await userService.getOneEmail(email, false);
 
   if (!user) {
     throw createError({
@@ -65,7 +65,7 @@ async function login(req, res) {
     id: user.id,
     email: user.email,
     username: user.username,
-    roleId: user.roleId,
+    role: user.Role.name,
   });
 
   res.status(200).json(
@@ -105,7 +105,7 @@ async function resendVerification(req, res) {
       const token = await authService.createVerificationToken(user.id);
       await sendVerificationEmail(email, token);
     } catch (error) {
-      // SMTP failure. Swallow to preserve consistent 200 (anti-enumeration)
+      if (error.statusCode === 429) throw error;
     }
   }
 
@@ -126,7 +126,7 @@ async function forgotPassword(req, res) {
       const token = await authService.createPasswordResetToken(user.id);
       await sendPasswordResetEmail(email, token);
     } catch (error) {
-      // SMTP failure. Swallow to preserve consistent 200 (anti-enumeration)
+      if (error.statusCode === 429) throw error;
     }
   }
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -30,7 +30,6 @@ async function register(req, res) {
     await sendVerificationEmail(email, verificationToken);
   } catch (error) {
     console.error("Failed to send verification email:", error.message, error.name);
-    // SMTP failure. User can resend via /auth/resend-verification
   }
 
   res.status(201).json(
@@ -106,7 +105,6 @@ async function resendVerification(req, res) {
       const token = await authService.createVerificationToken(user.id);
       await sendVerificationEmail(email, token);
     } catch (error) {
-      if (error.statusCode === 429) throw error;
       console.error("Failed to send verification email:", error.message, error.name);
     }
   }
@@ -128,7 +126,6 @@ async function forgotPassword(req, res) {
       const token = await authService.createPasswordResetToken(user.id);
       await sendPasswordResetEmail(email, token);
     } catch (error) {
-      if (error.statusCode === 429) throw error;
       console.error("Failed to send password reset email:", error.message, error.name);
     }
   }

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -29,6 +29,7 @@ async function register(req, res) {
     const verificationToken = await authService.createVerificationToken(user.id);
     await sendVerificationEmail(email, verificationToken);
   } catch (error) {
+    console.error("Failed to send verification email:", error.message, error.name);
     // SMTP failure. User can resend via /auth/resend-verification
   }
 
@@ -106,6 +107,7 @@ async function resendVerification(req, res) {
       await sendVerificationEmail(email, token);
     } catch (error) {
       if (error.statusCode === 429) throw error;
+      console.error("Failed to send verification email:", error.message, error.name);
     }
   }
 
@@ -127,6 +129,7 @@ async function forgotPassword(req, res) {
       await sendPasswordResetEmail(email, token);
     } catch (error) {
       if (error.statusCode === 429) throw error;
+      console.error("Failed to send password reset email:", error.message, error.name);
     }
   }
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -436,7 +436,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  * /auth/resend-verification:
  *   post:
  *     summary: Resend verification email
- *     description: Sends a new verification email if the address is registered and unverified. Returns 200 regardless of whether the email exists to prevent email enumeration. Returns 429 if the per-user cooldown or daily email limit is reached.
+ *     description: Sends a new verification email if the address is registered and unverified. Always returns 200 regardless of whether the email exists to prevent email enumeration. Per-user cooldown and daily limits are enforced server-side but do not surface as distinct responses.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -448,7 +448,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             email: john.doe@example.com
  *     responses:
  *       200:
- *         description: Request processed (returns success regardless of email existence to prevent enumeration)
+ *         description: Request processed (always returns success to prevent email enumeration)
  *         content:
  *           application/json:
  *             schema:
@@ -473,39 +473,13 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                 {field: "email", message: "Please provide a valid email"}
  *               ]
  *       429:
- *         description: Rate limited - either auth rate limit, per-user cooldown, or daily email limit
+ *         description: Too many authentication attempts - auth rate limit exceeded
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
- *             examples:
- *               authRateLimit:
- *                 summary: Auth route rate limit (15 req / 10 min)
- *                 value:
- *                   success: false
- *                   status: "error"
- *                   statusCode: 429
- *                   message: "Too many authentication attempts, please try again in 10 minutes."
- *               cooldown:
- *                 summary: Per-user cooldown (5 minutes between emails)
- *                 value:
- *                   success: false
- *                   status: "fail"
- *                   statusCode: 429
- *                   message: "Please wait before requesting another email."
- *               dailyLimit:
- *                 summary: Daily email limit reached (5 per day)
- *                 value:
- *                   success: false
- *                   status: "fail"
- *                   statusCode: 429
- *                   message: "Daily email limit reached. Please try again later."
  *         headers:
- *           Retry-After:
- *             description: Seconds until next request is allowed. Present on per-user cooldown responses and may also be present on auth rate limit responses.
- *             schema:
- *               type: integer
- *               example: 240
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Internal server error
  *         content:
@@ -519,7 +493,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  * /auth/forgot-password:
  *   post:
  *     summary: Request password reset
- *     description: Sends a password reset email if the address is registered. Returns 200 regardless of whether the email exists to prevent email enumeration. Returns 429 if the per-user cooldown or daily email limit is reached. Reset link is valid for 30 minutes.
+ *     description: Sends a password reset email if the address is registered. Always returns 200 regardless of whether the email exists to prevent email enumeration. Per-user cooldown and daily limits are enforced server-side but do not surface as distinct responses. Reset link is valid for 30 minutes.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -531,7 +505,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             email: john.doe@example.com
  *     responses:
  *       200:
- *         description: Request processed (returns success regardless of email existence to prevent enumeration)
+ *         description: Request processed (always returns success to prevent email enumeration)
  *         content:
  *           application/json:
  *             schema:
@@ -556,39 +530,13 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                 {field: "email", message: "Please provide a valid email"}
  *               ]
  *       429:
- *         description: Rate limited - either auth rate limit, per-user cooldown, or daily email limit
+ *         description: Too many authentication attempts - auth rate limit exceeded
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
- *             examples:
- *               authRateLimit:
- *                 summary: Auth route rate limit (15 req / 10 min)
- *                 value:
- *                   success: false
- *                   status: "error"
- *                   statusCode: 429
- *                   message: "Too many authentication attempts, please try again in 10 minutes."
- *               cooldown:
- *                 summary: Per-user cooldown (5 minutes between emails)
- *                 value:
- *                   success: false
- *                   status: "fail"
- *                   statusCode: 429
- *                   message: "Please wait before requesting another email."
- *               dailyLimit:
- *                 summary: Daily email limit reached (5 per day)
- *                 value:
- *                   success: false
- *                   status: "fail"
- *                   statusCode: 429
- *                   message: "Daily email limit reached. Please try again later."
  *         headers:
- *           Retry-After:
- *             description: Seconds until next request is allowed. Present on per-user cooldown responses and may also be present on auth rate limit responses.
- *             schema:
- *               type: integer
- *               example: 240
+ *           $ref: '#/components/headers/RateLimitHeaders'
  *       500:
  *         description: Internal server error
  *         content:

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -436,7 +436,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  * /auth/resend-verification:
  *   post:
  *     summary: Resend verification email
- *     description: Sends a new verification email if the address is registered and unverified. Always returns 200 regardless of whether the email exists to prevent email enumeration.
+ *     description: Sends a new verification email if the address is registered and unverified. Returns 200 regardless of whether the email exists to prevent email enumeration. Returns 429 if the per-user cooldown or daily email limit is reached.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -448,7 +448,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             email: john.doe@example.com
  *     responses:
  *       200:
- *         description: Request processed (always returns success to prevent email enumeration)
+ *         description: Request processed (returns success regardless of email existence to prevent enumeration)
  *         content:
  *           application/json:
  *             schema:
@@ -483,7 +483,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                 summary: Auth route rate limit (15 req / 10 min)
  *                 value:
  *                   success: false
- *                   status: "fail"
+ *                   status: "error"
  *                   statusCode: 429
  *                   message: "Too many authentication attempts, please try again in 10 minutes."
  *               cooldown:
@@ -502,7 +502,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                   message: "Daily email limit reached. Please try again later."
  *         headers:
  *           Retry-After:
- *             description: Seconds until next request is allowed (present on cooldown only, not on daily limit or auth rate limit)
+ *             description: Seconds until next request is allowed. Present on per-user cooldown responses and may also be present on auth rate limit responses.
  *             schema:
  *               type: integer
  *               example: 240
@@ -519,7 +519,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  * /auth/forgot-password:
  *   post:
  *     summary: Request password reset
- *     description: Sends a password reset email if the address is registered. Always returns 200 regardless of whether the email exists to prevent email enumeration. Reset link is valid for 30 minutes.
+ *     description: Sends a password reset email if the address is registered. Returns 200 regardless of whether the email exists to prevent email enumeration. Returns 429 if the per-user cooldown or daily email limit is reached. Reset link is valid for 30 minutes.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -531,7 +531,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             email: john.doe@example.com
  *     responses:
  *       200:
- *         description: Request processed (always returns success to prevent email enumeration)
+ *         description: Request processed (returns success regardless of email existence to prevent enumeration)
  *         content:
  *           application/json:
  *             schema:
@@ -566,7 +566,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                 summary: Auth route rate limit (15 req / 10 min)
  *                 value:
  *                   success: false
- *                   status: "fail"
+ *                   status: "error"
  *                   statusCode: 429
  *                   message: "Too many authentication attempts, please try again in 10 minutes."
  *               cooldown:
@@ -585,7 +585,7 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                   message: "Daily email limit reached. Please try again later."
  *         headers:
  *           Retry-After:
- *             description: Seconds until next request is allowed (present on cooldown only, not on daily limit or auth rate limit)
+ *             description: Seconds until next request is allowed. Present on per-user cooldown responses and may also be present on auth rate limit responses.
  *             schema:
  *               type: integer
  *               example: 240

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -473,13 +473,39 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                 {field: "email", message: "Please provide a valid email"}
  *               ]
  *       429:
- *         description: Too many authentication attempts - auth rate limit exceeded
+ *         description: Rate limited - either auth rate limit, per-user cooldown, or daily email limit
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
+ *             examples:
+ *               authRateLimit:
+ *                 summary: Auth route rate limit (15 req / 10 min)
+ *                 value:
+ *                   success: false
+ *                   status: "fail"
+ *                   statusCode: 429
+ *                   message: "Too many authentication attempts, please try again in 10 minutes."
+ *               cooldown:
+ *                 summary: Per-user cooldown (5 minutes between emails)
+ *                 value:
+ *                   success: false
+ *                   status: "fail"
+ *                   statusCode: 429
+ *                   message: "Please wait before requesting another email."
+ *               dailyLimit:
+ *                 summary: Daily email limit reached (5 per day)
+ *                 value:
+ *                   success: false
+ *                   status: "fail"
+ *                   statusCode: 429
+ *                   message: "Daily email limit reached. Please try again later."
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           Retry-After:
+ *             description: Seconds until next request is allowed (present on cooldown only, not on daily limit or auth rate limit)
+ *             schema:
+ *               type: integer
+ *               example: 240
  *       500:
  *         description: Internal server error
  *         content:
@@ -530,13 +556,39 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *                 {field: "email", message: "Please provide a valid email"}
  *               ]
  *       429:
- *         description: Too many authentication attempts - auth rate limit exceeded
+ *         description: Rate limited - either auth rate limit, per-user cooldown, or daily email limit
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
+ *             examples:
+ *               authRateLimit:
+ *                 summary: Auth route rate limit (15 req / 10 min)
+ *                 value:
+ *                   success: false
+ *                   status: "fail"
+ *                   statusCode: 429
+ *                   message: "Too many authentication attempts, please try again in 10 minutes."
+ *               cooldown:
+ *                 summary: Per-user cooldown (5 minutes between emails)
+ *                 value:
+ *                   success: false
+ *                   status: "fail"
+ *                   statusCode: 429
+ *                   message: "Please wait before requesting another email."
+ *               dailyLimit:
+ *                 summary: Daily email limit reached (5 per day)
+ *                 value:
+ *                   success: false
+ *                   status: "fail"
+ *                   statusCode: 429
+ *                   message: "Daily email limit reached. Please try again later."
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           Retry-After:
+ *             description: Seconds until next request is allowed (present on cooldown only, not on daily limit or auth rate limit)
+ *             schema:
+ *               type: integer
+ *               example: 240
  *       500:
  *         description: Internal server error
  *         content:

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -7,6 +7,16 @@ const TOKEN_EXPIRY_MS = new Map([
   ["password_reset", 30 * 60 * 1000],
 ]);
 
+const TOKEN_COOLDOWN_MS = new Map([
+  ["email_verification", 5 * 60 * 1000],
+  ["password_reset", 5 * 60 * 1000],
+]);
+
+const TOKEN_DAILY_LIMIT = new Map([
+  ["email_verification", 5],
+  ["password_reset", 5],
+]);
+
 class AuthService {
   constructor(db) {
     this.client = db.sequelize;
@@ -60,7 +70,46 @@ class AuthService {
     );
   }
 
+  async _enforceTokenLimits(userId, type) {
+    const cooldownMs = TOKEN_COOLDOWN_MS.get(type);
+    const dailyLimit = TOKEN_DAILY_LIMIT.get(type);
+
+    const recentToken = await this.Token.findOne({
+      where: {
+        userId,
+        type,
+        createdAt: { [Op.gt]: new Date(Date.now() - cooldownMs) },
+      },
+    });
+
+    if (recentToken) {
+      const retryAfterSeconds = Math.ceil((cooldownMs - (Date.now() - recentToken.createdAt.getTime())) / 1000);
+      const error = createError({
+        statusCode: 429,
+        message: "Please wait before requesting another email.",
+      });
+      error.retryAfter = retryAfterSeconds;
+      throw error;
+    }
+
+    const dailyCount = await this.Token.count({
+      where: {
+        userId,
+        type,
+        createdAt: { [Op.gt]: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+      },
+    });
+
+    if (dailyCount >= dailyLimit) {
+      throw createError({
+        statusCode: 429,
+        message: "Daily email limit reached. Please try again later.",
+      });
+    }
+  }
+
   async createVerificationToken(userId) {
+    await this._enforceTokenLimits(userId, "email_verification");
     await this._invalidateTokens(userId, "email_verification");
     const { plaintext } = await this._createToken(userId, "email_verification");
     return plaintext;
@@ -86,6 +135,7 @@ class AuthService {
   }
 
   async createPasswordResetToken(userId) {
+    await this._enforceTokenLimits(userId, "password_reset");
     await this._invalidateTokens(userId, "password_reset");
     const { plaintext } = await this._createToken(userId, "password_reset");
     return plaintext;

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -73,6 +73,9 @@ class AuthService {
   async _enforceTokenLimits(userId, type) {
     const cooldownMs = TOKEN_COOLDOWN_MS.get(type);
     const dailyLimit = TOKEN_DAILY_LIMIT.get(type);
+    if (cooldownMs == null || dailyLimit == null) {
+      throw new Error(`Unknown token type: ${type}`);
+    }
 
     const recentToken = await this.Token.findOne({
       where: {

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -86,7 +86,11 @@ class AuthService {
     });
 
     if (recentToken) {
-      const retryAfterSeconds = Math.ceil((cooldownMs - (Date.now() - recentToken.createdAt.getTime())) / 1000);
+      const elapsedMs = Date.now() - recentToken.createdAt.getTime();
+      const remainingMs = cooldownMs - elapsedMs;
+      const maxSeconds = Math.ceil(cooldownMs / 1000);
+      const retryAfterSeconds = Math.min(Math.max(Math.ceil(remainingMs / 1000), 1), maxSeconds);
+
       const error = createError({
         statusCode: 429,
         message: "Please wait before requesting another email.",

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -88,17 +88,10 @@ class AuthService {
     });
 
     if (recentToken) {
-      const elapsedMs = Date.now() - recentToken.createdAt.getTime();
-      const remainingMs = cooldownMs - elapsedMs;
-      const maxSeconds = Math.ceil(cooldownMs / 1000);
-      const retryAfterSeconds = Math.min(Math.max(Math.ceil(remainingMs / 1000), 1), maxSeconds);
-
-      const error = createError({
+      throw createError({
         statusCode: 429,
         message: "Please wait before requesting another email.",
       });
-      error.retryAfter = retryAfterSeconds;
-      throw error;
     }
 
     const dailyCount = await this.Token.count({

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -83,6 +83,8 @@ class AuthService {
         type,
         createdAt: { [Op.gt]: new Date(Date.now() - cooldownMs) },
       },
+      order: [["createdAt", "DESC"]],
+      attributes: ["createdAt"],
     });
 
     if (recentToken) {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -172,26 +172,16 @@ describe("AuthService", () => {
       expect(db.Token.count).toHaveBeenCalledTimes(1);
     });
 
-    it("throws 429 with retryAfter when a recent token exists", async () => {
+    it("throws 429 when a recent token exists", async () => {
       const recentToken = {
         createdAt: new Date(Date.now() - 60 * 1000),
       };
       db.Token.findOne.mockResolvedValue(recentToken);
 
-      const error = await authService._enforceTokenLimits("user-uuid-1", "email_verification").catch((e) => e);
-      expect(error.statusCode).toBe(429);
-      expect(error.message).toBe("Please wait before requesting another email.");
-      expect(error.retryAfter).toBeGreaterThan(0);
-      expect(error.retryAfter).toBeLessThanOrEqual(5 * 60);
-    });
-
-    it("calculates retryAfter as remaining cooldown seconds", async () => {
-      const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
-      db.Token.findOne.mockResolvedValue({ createdAt: twoMinutesAgo });
-
-      const error = await authService._enforceTokenLimits("user-uuid-1", "email_verification").catch((e) => e);
-      expect(error.retryAfter).toBeGreaterThanOrEqual(179);
-      expect(error.retryAfter).toBeLessThanOrEqual(181);
+      await expect(authService._enforceTokenLimits("user-uuid-1", "email_verification")).rejects.toMatchObject({
+        statusCode: 429,
+        message: "Please wait before requesting another email.",
+      });
     });
 
     it("skips daily limit check when cooldown is hit", async () => {
@@ -214,14 +204,6 @@ describe("AuthService", () => {
         statusCode: 429,
         message: "Daily email limit reached. Please try again later.",
       });
-    });
-
-    it("does not include retryAfter on daily limit error", async () => {
-      db.Token.findOne.mockResolvedValue(null);
-      db.Token.count.mockResolvedValue(5);
-
-      const error = await authService._enforceTokenLimits("user-uuid-1", "email_verification").catch((e) => e);
-      expect(error.retryAfter).toBeUndefined();
     });
 
     it("passes at count 4 but rejects at count 5", async () => {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -13,8 +13,9 @@ function createMockDb() {
     },
     Token: {
       create: jest.fn().mockResolvedValue({}),
-      findOne: jest.fn(),
+      findOne: jest.fn().mockResolvedValue(null),
       update: jest.fn().mockResolvedValue([1]),
+      count: jest.fn().mockResolvedValue(0),
     },
     User: {
       findByPk: jest.fn(),
@@ -157,6 +158,80 @@ describe("AuthService", () => {
 
       const options = db.Token.update.mock.calls[0][1];
       expect(options).not.toHaveProperty("transaction");
+    });
+  });
+
+  describe("_enforceTokenLimits", () => {
+    it("passes when no recent token and under daily limit", async () => {
+      db.Token.findOne.mockResolvedValue(null);
+      db.Token.count.mockResolvedValue(0);
+
+      await expect(authService._enforceTokenLimits("user-uuid-1", "email_verification")).resolves.toBeUndefined();
+
+      expect(db.Token.findOne).toHaveBeenCalledTimes(1);
+      expect(db.Token.count).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws 429 with retryAfter when a recent token exists", async () => {
+      const recentToken = {
+        createdAt: new Date(Date.now() - 60 * 1000),
+      };
+      db.Token.findOne.mockResolvedValue(recentToken);
+
+      const error = await authService._enforceTokenLimits("user-uuid-1", "email_verification").catch((e) => e);
+      expect(error.statusCode).toBe(429);
+      expect(error.message).toBe("Please wait before requesting another email.");
+      expect(error.retryAfter).toBeGreaterThan(0);
+      expect(error.retryAfter).toBeLessThanOrEqual(5 * 60);
+    });
+
+    it("calculates retryAfter as remaining cooldown seconds", async () => {
+      const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
+      db.Token.findOne.mockResolvedValue({ createdAt: twoMinutesAgo });
+
+      const error = await authService._enforceTokenLimits("user-uuid-1", "email_verification").catch((e) => e);
+      expect(error.retryAfter).toBeGreaterThanOrEqual(179);
+      expect(error.retryAfter).toBeLessThanOrEqual(181);
+    });
+
+    it("skips daily limit check when cooldown is hit", async () => {
+      db.Token.findOne.mockResolvedValue({
+        createdAt: new Date(Date.now() - 30 * 1000),
+      });
+
+      await expect(authService._enforceTokenLimits("user-uuid-1", "email_verification")).rejects.toMatchObject({
+        statusCode: 429,
+      });
+
+      expect(db.Token.count).not.toHaveBeenCalled();
+    });
+
+    it("throws 429 when daily limit is reached", async () => {
+      db.Token.findOne.mockResolvedValue(null);
+      db.Token.count.mockResolvedValue(5);
+
+      await expect(authService._enforceTokenLimits("user-uuid-1", "email_verification")).rejects.toMatchObject({
+        statusCode: 429,
+        message: "Daily email limit reached. Please try again later.",
+      });
+    });
+
+    it("does not include retryAfter on daily limit error", async () => {
+      db.Token.findOne.mockResolvedValue(null);
+      db.Token.count.mockResolvedValue(5);
+
+      const error = await authService._enforceTokenLimits("user-uuid-1", "email_verification").catch((e) => e);
+      expect(error.retryAfter).toBeUndefined();
+    });
+
+    it("passes at count 4 but rejects at count 5", async () => {
+      db.Token.findOne.mockResolvedValue(null);
+      db.Token.count.mockResolvedValue(4);
+      await expect(authService._enforceTokenLimits("user-uuid-1", "email_verification")).resolves.toBeUndefined();
+      db.Token.count.mockResolvedValue(5);
+      await expect(authService._enforceTokenLimits("user-uuid-1", "email_verification")).rejects.toMatchObject({
+        statusCode: 429,
+      });
     });
   });
 


### PR DESCRIPTION
Depends on pr #149 

Changes:
- Added per-user cooldown (5 min - should we make it 2-3 min?) and daily limit (5) on token creation for both
  email verification and password reset
- Cooldown and daily count are checked against the Token table directly using
  createdAt, (instead of suggested in-memory cache / extra table)
- Centralized error handler in app.js now sets Retry-After header when present
 - Updated auth tests and swagger docs.