### PR TITLE
feat: add project resurrection endpoint

### DIFF
--- a/controllers/projectController.js
+++ b/controllers/projectController.js
@@ -159,6 +159,19 @@ async function deleteProject(req, res) {
   );
 }
 
+async function resurrectProject(req, res) {
+  const { id } = req.params;
+  const { reason } = req.body;
+  const project = await projectService.resurrect(id, reason, req.user.id);
+  res.status(200).json(
+    successResponse({
+      message: "Project resurrected successfully",
+      data: project,
+      statusCode: 200,
+    })
+  );
+}
+
 module.exports = {
   getAll,
   getOneId,
@@ -169,4 +182,5 @@ module.exports = {
   addType,
   deleteProject,
   getAllTombstones,
+  resurrectProject,
 };

--- a/middleware/validateSchema.js
+++ b/middleware/validateSchema.js
@@ -2,7 +2,7 @@ const createError = require("../utilities/createError");
 
 const validateSchema = (schema) => async (req, res, next) => {
   try {
-    req.body = await schema.validate(req.body, { abortEarly: false });
+    req.body = await schema.validate(req.body, { abortEarly: false, stripUnknown: false });
     next();
   } catch (error) {
     if (error.name === "ValidationError") {

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -10,6 +10,7 @@ const {
   addType,
   removeType,
   getAllTombstones,
+  resurrectProject,
 } = require("../controllers/projectController");
 const asyncHandler = require("../middleware/asyncHandler");
 const {
@@ -21,7 +22,14 @@ const {
   ownsEntity,
   isLoggedIn,
 } = require("../middleware");
-const { projectSchema, projectUpdateSchema, typeIdSchema, uuidSchema, projectQuerySchema } = require("../schema");
+const {
+  projectSchema,
+  projectUpdateSchema,
+  typeIdSchema,
+  uuidSchema,
+  projectQuerySchema,
+  resurrectSchema,
+} = require("../schema");
 const { ProjectService } = require("../services");
 const { db } = require("../models");
 const projectService = new ProjectService(db);
@@ -70,6 +78,16 @@ router.delete(
   asyncHandler(hasRole("user")),
   asyncHandler(ownsEntity(projectService)),
   asyncHandler(removeType)
+);
+
+router.put(
+  "/:id/resurrect",
+  authenticate,
+  validateParamSchema(uuidSchema),
+  validateSchema(resurrectSchema),
+  asyncHandler(hasRole("user")),
+  asyncHandler(ownsEntity(projectService)),
+  asyncHandler(resurrectProject)
 );
 
 router.use("/", projectComments);
@@ -265,6 +283,17 @@ router.use("/", projectComments);
  *         typeId:
  *           type: integer
  *           example: 1
+ *
+ *     ResurrectProjectBody:
+ *       type: object
+ *       required:
+ *         - reason
+ *       properties:
+ *         reason:
+ *           type: string
+ *           maxLength: 255
+ *           description: Why the project is being resurrected. Must be non-empty after trimming whitespace.
+ *           example: "Found a co-founder willing to restart this with me."
  *
  *     ProjectArrayResponse:
  *       type: object
@@ -1025,5 +1054,90 @@ router.use("/", projectComments);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ProjectServerErrorResponse'
+ */
+/**
+ * @swagger
+ * /projects/{id}/resurrect:
+ *   put:
+ *     summary: Resurrect a buried project
+ *     description: >
+ *       Brings a buried project back to life by setting its status to "resurrected"
+ *       and recording a ResurrectionEvent. Only the project owner can resurrect their project,
+ *       and the project must currently have a status of "buried".
+ *     tags: [Projects]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: UUID of the project to resurrect.
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ResurrectProjectBody'
+ *     responses:
+ *       200:
+ *         description: Project resurrected successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ProjectSingleResponse'
+ *       400:
+ *         description: Validation error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ProjectValidationErrorResponse'
+ *       401:
+ *         description: Unauthorized.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Forbidden — user does not own the project.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Project not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ProjectNotFoundResponse'
+ *       409:
+ *         description: Project is not currently buried.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ProjectErrorResponse'
+ *       429:
+ *         description: Too many requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RateLimitResponse'
+ *         headers:
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/InternalErrorResponse'
  */
 module.exports = router;

--- a/schema/index.js
+++ b/schema/index.js
@@ -2,7 +2,7 @@ const { loginSchema } = require("./loginSchema");
 const { registerSchema } = require("./registerSchema");
 const { updateUserSchema } = require("./updateUserSchema");
 const { projectIdSchema, commentIdSchema, uuidSchema } = require("./params");
-const { projectSchema, projectUpdateSchema, typeIdSchema } = require("./projectSchema");
+const { projectSchema, projectUpdateSchema, typeIdSchema, resurrectSchema } = require("./projectSchema");
 const { createCommentSchema, updateCommentSchema } = require("./commentSchema");
 const { updatePasswordSchema, resetPasswordSchema } = require("./passwordSchema");
 const { verifyEmailSchema, emailSchema } = require("./emailSchema");
@@ -19,6 +19,7 @@ module.exports = {
   projectSchema,
   projectUpdateSchema,
   typeIdSchema,
+  resurrectSchema,
   updatePasswordSchema,
   resetPasswordSchema,
   verifyEmailSchema,

--- a/schema/projectSchema.js
+++ b/schema/projectSchema.js
@@ -50,7 +50,7 @@ const projectUpdateSchema = object()
         return !isNaN(startDate) ? schema.min(startDate, "End date must be after start date") : schema;
       }),
     tombstoneId: number("Tombstone ID must be a number").typeError("Tombstone ID must be a number").nullable(),
-    status: string().oneOf(["inactive", "active", "buried", "resurrected", "completed", "archived"]),
+    status: string().oneOf(["inactive", "active", "buried", "completed", "archived"]),
   })
   .test("datesDependency", "Both startDate and endDate must be provided together", (value) => {
     const { startDate, endDate } = value;
@@ -77,4 +77,12 @@ const typeIdSchema = object({
   typeId: number().required("Type ID is required"),
 }).noUnknown(true, "Unknown field in request body");
 
-module.exports = { projectSchema, projectUpdateSchema, typeIdSchema };
+const resurrectSchema = object({
+  reason: string()
+    .required("Reason is required")
+    .trim()
+    .min(1, "Reason can't be empty")
+    .max(255, "Reason must be under 255 characters"),
+}).noUnknown(true, "Unknown field in request body");
+
+module.exports = { projectSchema, projectUpdateSchema, typeIdSchema, resurrectSchema };

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -7,6 +7,7 @@ class ProjectService {
     this.Type = db.Type;
     this.User = db.User;
     this.Tombstone = db.Tombstone;
+    this.ResurrectionEvent = db.ResurrectionEvent;
   }
 
   async getAll(limit = 100, offset = 0, options = {}) {
@@ -242,6 +243,27 @@ class ProjectService {
       throw createError({ message: "Project not found", statusCode: 404 });
     }
     return this.Project.destroy({ where: { id } });
+  }
+
+  async resurrect(id, reason, currentUserId) {
+    await this.client.transaction(async (t) => {
+      const [affectedRows] = await this.Project.update(
+        { status: "resurrected" },
+        { where: { id, status: "buried" }, transaction: t }
+      );
+
+      if (affectedRows === 0) {
+        throw createError({
+          message: "Only buried projects can be resurrected",
+          statusCode: 409,
+          status: "fail",
+        });
+      }
+
+      await this.ResurrectionEvent.create({ projectId: id, reason }, { transaction: t });
+    });
+
+    return this.getOneId(id, currentUserId);
   }
 }
 

--- a/tests/projects.test.js
+++ b/tests/projects.test.js
@@ -8,6 +8,7 @@ const updateTests = require("./projects/update.test.js");
 const getTests = require("./projects/get.test.js");
 const deleteTests = require("./projects/delete.test.js");
 const projectTypesTests = require("./projects/projectTypes.test.js");
+const resurrectTests = require("./projects/resurrect.test.js");
 
 const createTestUser = (suffix = "", roleId) => ({
   firstName: "Crash",
@@ -23,12 +24,11 @@ const testProject = {
   name: "Productivity Graveyard",
   description: "A humorous app to memorialize abandoned dev projects.",
   causeOfDeath: "Dog Puked on the server",
-  status: "buried",
   startDate: "2024-10-01",
   endDate: "2025-01-15",
   eulogy: "Laid to rest after haunting VS Code for too long. Survived by hundreds of unused TODOs.",
   types: [2, 3],
-  tombstoneId: 1, // Assuming tombstoneId 1 exists
+  tombstoneId: 1,
 };
 
 const updateProject = {
@@ -75,4 +75,7 @@ describe("Projects API", () => {
 
   // ---------- Type Tests --------------
   projectTypesTests(config);
+
+  // ---------- Resurrect Tests --------------
+  resurrectTests(config);
 });

--- a/tests/projects/resurrect.test.js
+++ b/tests/projects/resurrect.test.js
@@ -1,0 +1,216 @@
+const request = require("supertest");
+const { generateToken } = require("../../utilities/jwt");
+
+function resurrectTests({ app, db, testProject, createTestUser, badToken, expiredToken, cleanUp }) {
+  describe("PUT /projects/:id/resurrect", () => {
+    let buriedProject;
+    let buriedProjectForOwnershipTest;
+    let projectFor255CharTest;
+    let alreadyResurrectedProject;
+    let activeProject;
+    let user;
+    let user2;
+    let token;
+    let token2;
+
+    beforeAll(async () => {
+      await db.sequelize.authenticate();
+      const role = await db.Role.findOne({ where: { name: "user" } });
+
+      await db.User.destroy({
+        where: { email: [createTestUser("1", role.id).email, createTestUser("2", role.id).email] },
+        force: true,
+      });
+
+      user = await db.User.create(createTestUser("1", role.id));
+      user2 = await db.User.create(createTestUser("2", role.id));
+
+      buriedProject = await db.Project.create({ ...testProject, status: "buried", userId: user.id });
+      buriedProjectForOwnershipTest = await db.Project.create({ ...testProject, status: "buried", userId: user.id });
+      projectFor255CharTest = await db.Project.create({ ...testProject, status: "buried", userId: user.id });
+      alreadyResurrectedProject = await db.Project.create({ ...testProject, status: "resurrected", userId: user.id });
+      activeProject = await db.Project.create({ ...testProject, status: "active", userId: user.id });
+
+      token = generateToken({ id: user.id, email: user.email, username: user.username, role: role.name });
+      token2 = generateToken({ id: user2.id, email: user2.email, username: user2.username, role: role.name });
+    });
+
+    afterAll(async () => {
+      await cleanUp([user.id, user2.id]);
+    });
+
+    it("should resurrect a buried project, return the updated project, and create a ResurrectionEvent", async () => {
+      const reason = "Found a co-founder willing to restart this with me.";
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe(buriedProject.id);
+      expect(res.body.data.status).toBe("resurrected");
+
+      const event = await db.ResurrectionEvent.findOne({ where: { projectId: buriedProject.id } });
+      expect(event).not.toBeNull();
+      expect(event.projectId).toBe(buriedProject.id);
+      expect(event.reason).toBe(reason);
+      expect(event.resurrectedAt).toBeInstanceOf(Date);
+      expect(Date.now() - event.resurrectedAt.getTime()).toBeLessThan(5000);
+      expect(event.isCompleted).toBe(false);
+      expect(event.buriedAgain).toBeNull();
+    });
+
+    it("should not create a ResurrectionEvent when resurrection is rejected", async () => {
+      await request(app)
+        .put(`/projects/${activeProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "This should fail." });
+
+      const events = await db.ResurrectionEvent.findAll({ where: { projectId: activeProject.id } });
+      expect(events).toHaveLength(0);
+    });
+
+    it("should return 409 when project is already resurrected", async () => {
+      const res = await request(app)
+        .put(`/projects/${alreadyResurrectedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "Trying again." });
+      expect(res.statusCode).toBe(409);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 409 when project status is active, not buried", async () => {
+      const res = await request(app)
+        .put(`/projects/${activeProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "This project is active." });
+      expect(res.statusCode).toBe(409);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 403 when a non-owner tries to resurrect a buried project", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProjectForOwnershipTest.id}/resurrect`)
+        .set("Authorization", `Bearer ${token2}`)
+        .send({ reason: "Not my project to resurrect." });
+      expect(res.statusCode).toBe(403);
+      expect(res.body.success).toBe(false);
+
+      const project = await db.Project.findByPk(buriedProjectForOwnershipTest.id);
+      expect(project.status).toBe("buried");
+    });
+
+    it("should return 401 with no token", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .send({ reason: "Ghost in the machine." });
+      expect(res.statusCode).toBe(401);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 401 with invalid token", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${badToken}`)
+        .send({ reason: "Ghost in the machine." });
+      expect(res.statusCode).toBe(401);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 401 with expired token", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${expiredToken}`)
+        .send({ reason: "Ghost in the machine." });
+      expect(res.statusCode).toBe(401);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 404 for a non-existent project", async () => {
+      const res = await request(app)
+        .put(`/projects/00000000-0000-0000-0000-000000000000/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "Into the void." });
+      expect(res.statusCode).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 400 for an invalid project ID format", async () => {
+      const res = await request(app)
+        .put(`/projects/not-a-uuid/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "Ghost in the machine." });
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 400 when reason is missing", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({});
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 400 when reason is whitespace only", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "   " });
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should return 400 when unknown fields are sent", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "Valid reason.", sneaky: "field" });
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should accept a reason of exactly 255 characters", async () => {
+      const res = await request(app)
+        .put(`/projects/${projectFor255CharTest.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "x".repeat(255) });
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it("should return 400 when reason exceeds 255 characters", async () => {
+      const res = await request(app)
+        .put(`/projects/${buriedProject.id}/resurrect`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ reason: "x".repeat(256) });
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should only succeed once when two requests race to resurrect the same project", async () => {
+      const racer = await db.Project.create({ ...testProject, status: "buried", userId: user.id });
+
+      const [a, b] = await Promise.all([
+        request(app)
+          .put(`/projects/${racer.id}/resurrect`)
+          .set("Authorization", `Bearer ${token}`)
+          .send({ reason: "First to the finish." }),
+        request(app)
+          .put(`/projects/${racer.id}/resurrect`)
+          .set("Authorization", `Bearer ${token}`)
+          .send({ reason: "Second attempt." }),
+      ]);
+
+      const codes = [a.statusCode, b.statusCode].sort();
+      expect(codes).toEqual([200, 409]);
+
+      const events = await db.ResurrectionEvent.findAll({ where: { projectId: racer.id } });
+      expect(events).toHaveLength(1);
+    });
+  });
+}
+
+module.exports = resurrectTests;

--- a/tests/projects/update.test.js
+++ b/tests/projects/update.test.js
@@ -202,8 +202,7 @@ function updateTests({ app, db, testProject, updateProject, createTestUser, badT
         expect.arrayContaining([
           expect.objectContaining({
             field: "status",
-            message:
-              "status must be one of the following values: inactive, active, buried, resurrected, completed, archived",
+            message: "status must be one of the following values: inactive, active, buried, completed, archived",
           }),
         ])
       );


### PR DESCRIPTION
### Changes

- PUT /projects/:id/resurrect: owner-only endpoint that transitions a project from buried to resurrected and writes a ResurrectionEvent in the same transaction
- Returns 409 if the project isn't buried
- Removed "resurrected" from projectUpdateSchema so you can't bypass the dedicated endpoint via PUT /projects/:id
- Fixed noUnknown validation being silently ignored across all schemas. Turns out Yup v1 strips unknown fields before the noUnknown test runs, so it was never actually throwing. Added stripUnknown: false to the validate call to fix it
- Tests cover happy path, 409/403/401/404/400 cases, boundary values, and a concurrent race
