### PR TITLE
fix: correct OpenAPI 3.0.0 response header $ref usage in swagger docs

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -1,11 +1,6 @@
 /**
  * @swagger
  * components:
- *   securitySchemes:
- *     bearerAuth:
- *       type: http
- *       scheme: bearer
- *       bearerFormat: JWT
  *   parameters:
  *     limitParam:
  *       name: limit
@@ -29,27 +24,26 @@
  *         default: 0
  *
  *   headers:
- *     RateLimitHeaders:
- *       RateLimit-Policy:
- *         description: The rate limit policy (limit and window size in seconds)
- *         schema:
- *           type: string
- *         example: "600;w=600"
- *       RateLimit-Limit:
- *         description: The number of allowed requests in the current period
- *         schema:
- *           type: integer
- *         example: 600
- *       RateLimit-Remaining:
- *         description: The number of remaining requests in the current period
- *         schema:
- *           type: integer
- *         example: 599
- *       RateLimit-Reset:
- *         description: Seconds remaining until the current rate limit window resets
- *         schema:
- *           type: integer
- *         example: 600
+ *     RateLimit-Policy:
+ *       description: The rate limit policy (limit and window size in seconds)
+ *       schema:
+ *         type: string
+ *       example: "600;w=600"
+ *     RateLimit-Limit:
+ *       description: The number of allowed requests in the current period
+ *       schema:
+ *         type: integer
+ *       example: 600
+ *     RateLimit-Remaining:
+ *       description: The number of remaining requests in the current period
+ *       schema:
+ *         type: integer
+ *       example: 599
+ *     RateLimit-Reset:
+ *       description: Seconds remaining until the current rate limit window resets
+ *       schema:
+ *         type: integer
+ *       example: 600
  *
  * #-------------------------------
  * # Reusable Error Responses

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -265,7 +265,14 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -354,7 +361,14 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -422,7 +436,14 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -479,7 +500,14 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -536,7 +564,14 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -616,7 +651,14 @@ router.post("/reset-password", validateSchema(resetPasswordSchema), asyncHandler
  *             schema:
  *               $ref: '#/components/schemas/AuthRateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -114,7 +114,14 @@ router.delete(
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -179,7 +186,14 @@ router.delete(
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:

--- a/routes/projectComments.js
+++ b/routes/projectComments.js
@@ -241,7 +241,14 @@ router.get("/:projectId/comments", validateParamSchema(projectIdSchema), asyncHa
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -288,7 +295,14 @@ router.get("/:projectId/comments", validateParamSchema(projectIdSchema), asyncHa
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -581,7 +581,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -611,7 +618,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -641,7 +655,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -693,7 +714,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -742,7 +770,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -811,7 +846,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -868,7 +910,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -946,7 +995,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:
@@ -1018,7 +1074,14 @@ router.use("/", projectComments);
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error.
  *         content:

--- a/routes/users.js
+++ b/routes/users.js
@@ -259,7 +259,14 @@ router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -333,7 +340,14 @@ router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -443,7 +457,14 @@ router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -552,7 +573,14 @@ router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:
@@ -596,7 +624,14 @@ router.delete("/me", asyncHandler(authenticate), asyncHandler(softDeletedUser));
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -71,7 +71,14 @@ router.post("/:projectId/toggle", validateParamSchema(projectIdSchema), authenti
  *             schema:
  *               $ref: '#/components/schemas/RateLimitResponse'
  *         headers:
- *           $ref: '#/components/headers/RateLimitHeaders'
+ *           RateLimit-Policy:
+ *             $ref: '#/components/headers/RateLimit-Policy'
+ *           RateLimit-Limit:
+ *             $ref: '#/components/headers/RateLimit-Limit'
+ *           RateLimit-Remaining:
+ *             $ref: '#/components/headers/RateLimit-Remaining'
+ *           RateLimit-Reset:
+ *             $ref: '#/components/headers/RateLimit-Reset'
  *       500:
  *         description: Internal server error
  *         content:


### PR DESCRIPTION
In OpenAPI 3.0.0, the headers field in a Response Object is Map[string, Header Object | Reference Object]. Individual entries can use $ref, but the map itself cant. The previous code used headers: $ref: '#/components/headers/RateLimitHeaders' which is invalid per spec, and it would be parsed as a header literally named $ref.


- docs/index.js: flattened RateLimitHeaders (invalid grouped object) into four individual named Header Objects (RateLimit-- Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset) under components.headers
- docs/index.js:  removed duplicate securitySchemes.bearerAuth definition (already defined in swagger.js)
- updated all 429 response headers blocks to reference each header individually